### PR TITLE
fix signature for lang functions

### DIFF
--- a/source/docs/docmap.json
+++ b/source/docs/docmap.json
@@ -207,17 +207,17 @@
         "_title" : "Internationalization",
         "changing-language" : {
             "_title" : "Changing languages",
-            "_signature" : "moment().lang(String);\nmoment().lang(String, Object);",
+            "_signature" : "moment.lang(String);\nmoment.lang(String, Object);",
             "_version" : "1.0.0"
         },
         "loading-into-nodejs" : {
             "_title" : "Loading languages in NodeJS",
-            "_signature" : "moment().lang(String);",
+            "_signature" : "moment.lang(String);",
             "_version" : "1.0.0"
         },
         "loading-into-browser" : {
             "_title" : "Loading languages in the browser",
-            "_signature" : "moment().lang(String);",
+            "_signature" : "moment.lang(String);",
             "_version" : "1.0.0"
         },
         "adding-language" : {


### PR DESCRIPTION
The `lang` function is not on the prototype, so it cannot be invoked on instances.

I did not rebuild the site, I only changed the docmap.
