### PR TITLE
+ cdnjs instructions in Where to use it/browser

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -326,6 +326,7 @@ moment().format();
     moment().format();
 &lt;/script>
 </pre></div>
+						<p>If you want to use the power of a <a href='http://cdnjs.com/'>CDN</a>, replace the "moment.js" with "//cdnjs.cloudflare.com/ajax/libs/moment.js/VERSION/moment.min.js", then replace VERSION with the full version number.</p>
 					</div>
 				</article>
 			


### PR DESCRIPTION
To help prevent people from using rawgithub.com as a CDN (#44), & **may** help some improve 'time to glass' webpage performance.
