### PR TITLE
Added --localhost grunt option

### DIFF
--- a/source/tasks/html.js
+++ b/source/tasks/html.js
@@ -25,14 +25,16 @@ function filename(fn) {
     return output;
 }
 
-function main(cb) {
+function main(grunt, cb) {
     var data = {
         library : library,
         core_docs : docs.core(),
         timezone_docs : docs.timezone(),
         zones : zones,
         langs : langs,
-        cachebust : moment().format()
+        cachebust : moment().format(),
+        global : grunt.option("localhost") && 'global' || 'global.min',
+        localhost : grunt.option("localhost") && process.cwd() || ''
     };
     library.ready(function(){
         render(data, cb);
@@ -67,6 +69,6 @@ function render(data, cb) {
 
 module.exports = function(grunt) {
     grunt.registerTask('html', 'Build HTML', function() {
-        main(this.async());
+        main(grunt, this.async());
     });
 };

--- a/source/templates/base.html
+++ b/source/templates/base.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<link href='http://fonts.googleapis.com/css?family=Roboto+Slab:300,700' rel='stylesheet' type='text/css'>
-		<link rel="stylesheet" href="/static/css/style.css?v={{ cachebust }}" />
+		<link rel="stylesheet" href="{{ localhost }}/static/css/style.css?v={{ cachebust }}" />
 		<title>Moment.js | {% block title %}{% endblock title %}</title>
 	</head>
 	<body class="{% block body_class %}{% endblock body_class %}">
@@ -22,7 +22,7 @@
 		</footer>
 
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
-		<script src="/static/js/global.min.js?v={{ cachebust }}"></script>
+		<script src="{{ localhost }}/static/js/{{ global }}.js?v={{ cachebust }}"></script>
 		{% block scripts %}{% endblock scripts %}
 
 		<script>

--- a/source/templates/core-home.html
+++ b/source/templates/core-home.html
@@ -12,7 +12,7 @@
 {% endblock header %}
 
 {% block scripts %}
-	<script src="/static/js/core-home.js?v={{ cachebust }}"></script>
+	<script src="{{ localhost }}/static/js/core-home.js?v={{ cachebust }}"></script>
 {% endblock scripts %}
 
 {% block content %}

--- a/source/templates/core-test.html
+++ b/source/templates/core-test.html
@@ -5,7 +5,7 @@
 {% block title %}Unit Tests{% endblock title %}
 
 {% block scripts %}
-	<script src="/static/js/core-test.js?v={{ cachebust }}"></script>
+	<script src="{{ localhost }}/static/js/core-test.js?v={{ cachebust }}"></script>
 {% endblock scripts %}
 
 {% block header %}


### PR DESCRIPTION
--localhost makes the links inside the generated html files point to the
corresponding files on the local machine. This is suitable to point a browser
to the locally generated html and run tests for example.

A better solution would be to use Karma to run tests in multiple browsers
automatically as part of continuous integration.
