### PR TITLE
Added msdate plugin documentation

### DIFF
--- a/source/core_docs/plugins/msdate.md
+++ b/source/core_docs/plugins/msdate.md
@@ -14,24 +14,4 @@ Or, convert an OA date to a `moment`:
 
 `moment.fromOADate(41493);` returns `Wed Aug 07 2013 00:00:00 GMT-0600 (MDT)`
 
-For exact date _and_ time (time is the value right of the decimal):
-
-`moment.fromOADate(41493.706892280097000);` returns `Wed Aug 07 2013 16:57:55 GMT-0600 (MDT)`
-
-To use with Moment formatting:
-
-```javascript
-//convert OA Date into JavaScript date
-var momentDate = moment.fromOADate(41493.706892280097000);
-
-//use Moment's awesomeness
-var formattedDate = momentDate.format('MMM Do YY);
-
-//formattedDate === "Aug 7th 13"
-```
-
-This could easily be chained together as:
-
-`moment.fromOADate(41493.706892280097000).format('MMM Do YY); //Aug 7th 13`
-
-More information can be found on GitHub at [http://markitondemand.github.io/moment-msdate/](http://markitondemand.github.io/moment-msdate/).
+More information and detailed docs can be found on GitHub at [http://markitondemand.github.io/moment-msdate/](http://markitondemand.github.io/moment-msdate/).


### PR DESCRIPTION
At Markit On Demand, we use "Microsoft Dates" which are more officially called OLE Automation dates in our databases. We wrote a quick plugin to convert OA dates to JavaScript dates for use alongside `moment.js`.
