### PR TITLE
small typo in the docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -918,7 +918,7 @@ moment().day(<span class="number">7</span>); <span class="comment">// next Sunda
 moment().day(<span class="number">10</span>); <span class="comment">// next Wednesday (3 + 7)</span>
 moment().day(<span class="number">24</span>); <span class="comment">// 3 Wednesdays from now (3 + 7 + 7 + 7)</span></code></pre>
 <p><em>Note:</em> <code>Moment#date</code> is for the date of the month, and <code>Moment#day</code> is for the day of the week.</p>
-<p>As of <strong>2.1.0</strong>, a day name is also supported. This is parsed in the moment&#39;s current locale.</p>
+<p>As of <strong>2.1.0</strong>, a weekday name is also supported. This is parsed in the moment&#39;s current locale.</p>
 <pre><code class="lang-javascript">moment().day(<span class="string">"Sunday"</span>);
 moment().day(<span class="string">"Monday"</span>);</code></pre>
 


### PR DESCRIPTION
`moment().day('Sunday')` is about the _day_ name (not the week name)
