### PR TITLE
Missing word

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2295,7 +2295,7 @@ b.diff(a) <span class="comment">// b - a &lt; 0</span></code></pre>
 						
 							<pre lang="javascript">moment().unix();</pre>
 						
-						<p><code>moment#unix</code> outputs a Unix timestamp (the of seconds since the Unix Epoch).</p>
+						<p><code>moment#unix</code> outputs a Unix timestamp (the number of seconds since the Unix Epoch).</p>
 <pre><code class="lang-javascript">moment(<span class="number">1318874398806</span>).unix(); <span class="comment">// 1318874398</span></code></pre>
 <p>This value is floored to the nearest second, and does not include a milliseconds component.</p>
 


### PR DESCRIPTION
Add missing word to `moment().unix()` description.
