### PR TITLE
Add usage docs for moment.tz

### DIFF
--- a/source/data/timezone_docs.json
+++ b/source/data/timezone_docs.json
@@ -13,5 +13,19 @@
 				"key": "Require.js"
 			}
 		]
+	},
+	{
+		"key": "how-to",
+		"title": "How to use it",
+		"methods": [
+			{
+				"key": "Constructor",
+				"signature": "moment.tz(..., String);"
+			},
+			{
+				"key": "Mutator",
+				"signature": "moment(...).tz(String);"
+			}
+		]
 	}
 ]

--- a/source/timezone_docs/how-to/constructor.md
+++ b/source/timezone_docs/how-to/constructor.md
@@ -1,0 +1,7 @@
+The `moment.tz` constructor takes all the same arguments as the `moment`
+constructor, but will interpret the last argument as a time zone identifier.
+
+```javascript
+moment.tz("2013-11-18 11:55", "America/Toronto").format(); // "2013-11-18T11:55:00-05:00"
+moment.tz(new Date(2013, 11, 18), "America/Toronto").format(); // "2013-12-18T00:00:00-05:00"
+```

--- a/source/timezone_docs/how-to/mutator.md
+++ b/source/timezone_docs/how-to/mutator.md
@@ -1,0 +1,17 @@
+The `.tz` mutator will set the timezone to the provided time zone identifier and 
+update the offset.
+
+```javascript
+moment("2013-11-18").tz("America/Toronto").zone(); // 300
+moment("2013-11-18").tz("Europe/Berlin").zone(); // -60
+```
+
+This information is used consistently in other operations, like calculating the 
+start of the day.
+
+```javascript
+var m = moment("2013-11-18 11:55");
+m.tz("America/Toronto").format(); // "2013-11-18T11:55:00-05:00"
+m.startOf("day").format(); // "2013-11-18T00:00:00-05:00"
+m.tz("Europe/Berlin").format(); // "2013-11-18T06:00:00+01:00"
+```


### PR DESCRIPTION
I'm not sure what the protocol is here, but I just modified the source files. I'm assuming leaving it up to deployers to rebuild the actual html is the right way to go?

![image](https://f.cloud.github.com/assets/150329/1560647/77eada50-5010-11e3-8ba7-b14c46bfa40e.png)
Screenshot of the rendered docs.
