### PR TITLE
Missing word in .unix()

### DIFF
--- a/source/core_docs/displaying/unix-timestamp.md
+++ b/source/core_docs/displaying/unix-timestamp.md
@@ -1,4 +1,4 @@
-`moment#unix` outputs a Unix timestamp (the of seconds since the Unix Epoch).
+`moment#unix` outputs a Unix timestamp (the number of seconds since the Unix Epoch).
 
 ```javascript
 moment(1318874398806).unix(); // 1318874398


### PR DESCRIPTION
Missing word in `.unix()` description.
