### PR TITLE
Note re: paths option (fixes #1676)

### DIFF
--- a/source/core_docs/use-it/require-js.md
+++ b/source/core_docs/use-it/require-js.md
@@ -25,3 +25,5 @@ For version `2.5.x`, in case you use other plugins that rely on Moment but are
 not AMD-compatible you may need to add [`wrapShim:
 true`](https://github.com/jrburke/r.js/blob/b8a6982d2923ae8389355edaa50d2b7f8065a01a/build/example.build.js#L68-L78)
 to your r.js config.
+
+__Note:__ Because of plugins, moment __must__ be loaded exactly as as `"moment"`, using `paths` to determine the directory. Requiring moment as eg, `"vendor\moment"` will return `undefined`. 


### PR DESCRIPTION
Note moment requires the paths option to load from a different folder, otherwise will return undefined. Fixes #1676.
