### PR TITLE
Update bower package name to 'moment' for consistency

### DIFF
--- a/source/core_docs/use-it/bower.md
+++ b/source/core_docs/use-it/bower.md
@@ -1,5 +1,5 @@
 ```
-bower install --save momentjs
+bower install --save moment
 ```
 
 Notable files are `moment.js`, `lang/*.js` and `min/moment-with-langs.js`.

--- a/source/templates/core-base.html
+++ b/source/templates/core-base.html
@@ -43,7 +43,7 @@
 		</a>
 	</div>
 	<div class="section">
-		<pre class="shell"><code>bower install -S momentjs</code></pre>
+		<pre class="shell"><code>bower install -S moment</code></pre>
 		<pre class="shell"><code>npm install --save moment</code></pre>
 		<pre class="pm"><code>Install-Package Moment.js</code></pre>
 	</div>


### PR DESCRIPTION
moment was registered with bower (via `bower register`) as both `moment` and `momentjs`. bower can't tell that these are the same packages.

Consider a project that depends on `momentjs` and `moment-range`:

```
my-application
├── momentjs (2.6.0)
├─┬ moment-range (2.6.0)
  └── moment (2.6.0)
```

Both `moment` and `momentjs` will be downloaded.

Considering that moment's own bower.json lists the package's name as `moment` [[0](https://github.com/moment/moment/blob/develop/bower.json#L2)], the NPM package is called `moment`, and important plugins depend on `moment` [[1](https://github.com/gf3/moment-range/issues/38)][[2](https://github.com/icambron/twix.js/pull/38)], update the docs to recommend `moment` when installing with bower.
