### PR TITLE
Add ISO 8601 to format documentation

### DIFF
--- a/docs/moment/04-displaying/01-format.md
+++ b/docs/moment/04-displaying/01-format.md
@@ -10,6 +10,7 @@ signature: |
 This is the most robust display option. It takes a string of tokens and replaces them with their corresponding values.
 
 ```javascript
+moment().format();                                // "2014-09-08T08:02:17-05:00" (ISO 8601)
 moment().format("dddd, MMMM Do YYYY, h:mm:ss a"); // "Sunday, February 14th 2010, 3:25:50 pm"
 moment().format("ddd, hA");                       // "Sun, 3PM"
 moment('gibberish').format('YYYY MM DD');         // "Invalid date"


### PR DESCRIPTION
This PR adds ISO 8601 documentation to the `format` function documentation.  I did not find the docs obvious here (see http://stackoverflow.com/q/25725019/614523).
