### PR TITLE
Add 'quarter' option to .add() documentation

### DIFF
--- a/docs/moment/03-manipulating/01-add.md
+++ b/docs/moment/03-manipulating/01-add.md
@@ -33,7 +33,7 @@ moment().add(7, 'd');
       <td>y</td>
     </tr>
     <tr>
-      <td>quarter</td>
+      <td>quarters</td>
       <td>Q</td>
     </tr>
     <tr>


### PR DESCRIPTION
Currently 'quarter' (shorthand Q) is an undocumented option for add/subtract. This PR adds quarter to the documentation. 
