### PR TITLE
use explicit timezone in the comment

### DIFF
--- a/docs/moment/01-parsing/11-asp-net-json-date.md
+++ b/docs/moment/01-parsing/11-asp-net-json-date.md
@@ -11,5 +11,5 @@ ASP.NET returns dates in JSON as `/Date(1198908717056)/` or `/Date(1198908717056
 If a string that matches this format is passed in, it will be parsed correctly.
 
 ```javascript
-moment("/Date(1198908717056-0700)/"); // December 28 2007 10:11 PM
+moment("/Date(1198908717056-0700)/"); // 2007-12-28T23:11:57.056-07:00
 ```


### PR DESCRIPTION
`December 28 2007 10:11 PM` is correct only in `-0800` timezone. Use `-0700` timezone that is mentioned in  the input JSON Date instead. Use rfc 3339 format to avoid ambiguity.
