### PR TITLE
Added 'hours' to the descriptions list.

### DIFF
--- a/docs/moment/07-customization/12-relative-time-threshold.md
+++ b/docs/moment/07-customization/12-relative-time-threshold.md
@@ -26,6 +26,11 @@ signature: |
       <td>least number of minutes to be considered an hour</td>
     </tr>
     <tr>
+      <td>h</td>
+      <td>hours</td>
+      <td>least number of hours to be considered a day</td>
+    </tr>
+    <tr>
       <td>d</td>
       <td>days</td>
       <td>least number of days to be considered a month</td>


### PR DESCRIPTION
Hours is the only description missing from the table. Added it in for completeness.
