### PR TITLE
Documentation for moment.tz.setDefault.

### DIFF
--- a/docs/moment-timezone/01-using-timezones/05-default-timezone.md
+++ b/docs/moment-timezone/01-using-timezones/05-default-timezone.md
@@ -1,0 +1,17 @@
+---
+title: Default time zone
+signature: |
+  moment.tz.setDefault(String);
+---
+
+
+By default, `moment` objects are created in the local time zone.
+To change the default time zone, use `moment.tz.setDefault` with a valid
+time zone.
+
+```js
+moment.tz.setDefault("America/New_York");
+```
+
+Subsequent calls to `moment.tz.setDefault` will not affect existing `moment`
+objects or their clones.


### PR DESCRIPTION
Document setting the default time zone, per [moment-timezone#15](https://github.com/moment/moment-timezone/issues/15).