### PR TITLE
Fix typo in Day of Week section

### DIFF
--- a/docs/moment/02-get-set/06-day.md
+++ b/docs/moment/02-get-set/06-day.md
@@ -24,7 +24,7 @@ moment().day(24); // 3 Wednesdays from now (3 + 7 + 7 + 7)
 
 **Note:** `Moment#date` is for the date of the month, and `Moment#day` is for the day of the week.
 
-As of **2.1.0**, a week name is also supported. This is parsed in the moment's current locale.
+As of **2.1.0**, a day name is also supported. This is parsed in the moment's current locale.
 
 ```javascript
 moment().day("Sunday");


### PR DESCRIPTION
I noticed a typo when looking for documentation on how to retrieve the day of the week. You enter a name of a day but it says that a week name is supported.