### PR TITLE
Update 01-creating.md to mention that moment supports ISO8601 duration parsing

### DIFF
--- a/docs/moment/08-durations/01-creating.md
+++ b/docs/moment/08-durations/01-creating.md
@@ -94,3 +94,10 @@ moment.duration('23:59:59.999');
 moment.duration('7.23:59:59.999');
 moment.duration('23:59');          //added in 2.3.0
 ```
+
+As of **2.3.0**, moment also supports parsing [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601#Time_intervals) durations.
+
+```javascript
+moment.duration('P1Y2M3DT4H5M6S');
+moment.duration('P1M');
+```


### PR DESCRIPTION
I couldn't find anywhere in the documentation where it says that moment supports parsing the ISO 8601 duration standard so I added it. Let me know if I need to add more to the description.