### PR TITLE
Fixing docs for Twitter plugin usage

### DIFF
--- a/docs/moment/10-plugins/05-twitter.md
+++ b/docs/moment/10-plugins/05-twitter.md
@@ -8,14 +8,14 @@ If you're trying to format times for tweets like the way Twitter does, you can u
 It's a simple way to display both short and long versions of human-readable timestamps.
 
 ```javascript
-moment().subtract(5, 'hours').twitter();
+moment().subtract(5, 'hours').twitterLong();
 // 5 hours
 ```
 
 Yes, it does smart pluralization.
 
 ```javascript
-moment().subtract(1, 'hour').twitter();
+moment().subtract(1, 'hour').twitterLong();
 // 1 hour
 ```
 


### PR DESCRIPTION
`twitter` is an alias for `twitterShort`, but these first 2 examples are showing the `twitterLong` form.