### PR TITLE
Added some padding to the document content

### DIFF
--- a/assets/css/common/_docs.scss
+++ b/assets/css/common/_docs.scss
@@ -90,6 +90,7 @@
 .docs-content {
 	margin-right: 25%;
 	padding-right: 20px;
+	padding-left: 10px;
 	color: $black;
 }
 


### PR DESCRIPTION
When the screen is reduced, the documentation text is sticking the left border. Adding some padding could be nicer.
