### PR TITLE
Clarifies duration().milliseconds() use case

### DIFF
--- a/docs/moment/08-durations/03-milliseconds.md
+++ b/docs/moment/08-durations/03-milliseconds.md
@@ -7,7 +7,7 @@ signature: |
 ---
 
 
-To get the number of milliseconds in a duration, use `moment.duration().milliseconds()`.
+To get the millisecond remainder of a duration, use `moment.duration().milliseconds()`.
 
 It will return a number between 0 and 999.
 


### PR DESCRIPTION
The previous wording ("milliseconds in a duration") was confusing in that it could be parsed to have the same meaning as "the length of the duration in milliseconds," (the current description of `asMilliseconds()`).