### PR TITLE
Switched around the slashes

### DIFF
--- a/docs/moment/01-parsing/03-string-format.md
+++ b/docs/moment/01-parsing/03-string-format.md
@@ -19,7 +19,7 @@ The parser ignores non-alphanumeric characters, so both of the following will re
 
 ```javascript
 moment("12-25-1995", "MM-DD-YYYY");
-moment("12\25\1995", "MM-DD-YYYY");
+moment("12/25/1995", "MM-DD-YYYY");
 ```
 
 The parsing tokens are similar to the formatting tokens used in `moment#format`.


### PR DESCRIPTION
The previous slashes (\) are used for escaping characters which messed this example up.