### PR TITLE
Updating utcOffset docs for +/- requirement

### DIFF
--- a/docs/moment/03-manipulating/09-utc-offset.md
+++ b/docs/moment/03-manipulating/09-utc-offset.md
@@ -39,7 +39,7 @@ It is also possible to set the utc offset from a string.
 
 ```javascript
 // these are equivalent
-moment().utcOffset("08:00");
+moment().utcOffset("+08:00");
 moment().utcOffset(8);
 moment().utcOffset(480);
 ```
@@ -47,6 +47,9 @@ moment().utcOffset(480);
 `moment#utcOffset` will search the string for the first match of `+00:00 +0000
 -00:00 -0000`, so you can even pass an ISO8601 formatted string and the moment
 will be changed to that utc offset.
+
+Note that the string is required to start with the `+` or `-` character.  Passing a string that
+does not start with `+` or `-` will be interpreted as if it were `"+00:00"`.
 
 ```javascript
 moment().utcOffset("2013-03-07T07:00:00+08:00");


### PR DESCRIPTION
Per moment/moment#2432, passing a string that does not start with `+` or `-` is interpreted as UTC.  This is the intended behavior, so updating docs accordingly.