### PR TITLE
Fix outdated doc about changing locale

### DIFF
--- a/docs/moment/06-i18n/01-changing-locale.md
+++ b/docs/moment/06-i18n/01-changing-locale.md
@@ -90,6 +90,18 @@ moment.locale('en');
 moment(1316116057189).fromNow() // an hour ago
 ```
 
+As of **2.8.0**, changing the global locale doesn't affect existing instances.
+
+```javascript
+moment.locale('fr');
+var m = moment(1316116057189);
+m.fromNow(); // il y a une heure
+
+moment.locale('en');
+m.fromNow(); // il y a une heure
+moment(1316116057189).fromNow(); // an hour ago
+```
+
 `moment.locale` returns the locale used. This is useful because Moment won't change locales if it doesn't know the one you specify.
 
 ```javascript

--- a/docs/moment/06-i18n/02-instance-locale.md
+++ b/docs/moment/06-i18n/02-instance-locale.md
@@ -16,20 +16,19 @@ In **1.7.0** we added instance specific locale configurations.
 
 ```javascript
 moment.locale('en'); // default the locale to English
-var globalLocale = moment();
 var localLocale = moment();
 
 localLocale.locale('fr'); // set this instance to use French
 localLocale.format('LLLL'); // dimanche 15 juillet 2012 11:01
-globalLocale.format('LLLL'); // Sunday, July 15 2012 11:01 AM
+moment().format('LLLL'); // Sunday, July 15 2012 11:01 AM
 
 moment.locale('es'); // change the global locale to Spanish
 localLocale.format('LLLL'); // dimanche 15 juillet 2012 11:01
-globalLocale.format('LLLL'); // Domingo 15 Julio 2012 11:03
+moment().format('LLLL'); // Domingo 15 Julio 2012 11:01
 
 localLocale.locale(false); // reset the instance locale
-localLocale.format('LLLL'); // Domingo 15 Julio 2012 11:03
-globalLocale.format('LLLL'); // Domingo 15 Julio 2012 11:03
+localLocale.format('LLLL'); // Domingo 15 Julio 2012 11:01
+moment().format('LLLL'); // Domingo 15 Julio 2012 11:01
 ```
 
 If you call `moment#locale` with no parameters, you get back the locale configuration that would be used for that moment.


### PR DESCRIPTION
The global locale only applies to newly created moments, see [2.8.0 changelog](https://gist.github.com/ichernev/ac3899324a5fa6c8c9b4)