### PR TITLE
Improve locales name for Korean

### DIFF
--- a/data/locale.js
+++ b/data/locale.js
@@ -45,7 +45,7 @@ var locales = {
     'ja'     : 'Japanese',
     'ka'     : 'Georgian',
     'km'     : 'Khmer (Cambodia)',
-    'ko'     : 'Korean',
+    'ko'     : 'Korean (한국어)',
     'lb'     : 'Luxembourgish',
     'lt'     : 'Lithuanian',
     'lv'     : 'Latvian',


### PR DESCRIPTION
`한국어` is locally word meaning `Korean`.
Thanks for great jobs.
:+1: 