### PR TITLE
Update jdateformatparser documentation

### DIFF
--- a/docs/moment/10-plugins/12-jdateformatparser.md
+++ b/docs/moment/10-plugins/12-jdateformatparser.md
@@ -11,8 +11,8 @@ If you want to work with the `java.text.DateFormat` you can use this plugin.
 For example,
 
 ```javascript
-moment("2013-12-24 14:30").formatWithJavaDateFormat("dd.MM.yyyy");  // returns the formatted date "24.12.2013"
-moment().toJavaDateFormatString("DD.MM.YYYY");  // returns the Java format pattern "dd.MM.yyyy"
+moment("2013-12-24 14:30").formatWithJDF("dd.MM.yyyy");  // returns the formatted date "24.12.2013"
+moment().toJDFString("DD.MM.YYYY");  // returns the Java format pattern "dd.MM.yyyy"
 ```
 
 The repository is located at [github.com/MadMG/moment-jdateformatparser](https://github.com/MadMG/moment-jdateformatparser)


### PR DESCRIPTION
It seems that the API changed now to some short form. This PR is based on moment-jdateformatparser#1.0.0