### PR TITLE
The display for length of time is incorrect for 0 to 45 seconds

### DIFF
--- a/docs/moment/04-displaying/02-fromnow.md
+++ b/docs/moment/04-displaying/02-fromnow.md
@@ -36,7 +36,7 @@ The breakdown of which string is displayed for each length of time is outlined i
     <tr>
       <td>0 to 45 seconds</td>
       <td>s</td>
-      <td>seconds ago</td>
+      <td>a few seconds ago</td>
     </tr>
     <tr>
       <td>45 to 90 seconds</td>


### PR DESCRIPTION
User might expect moment().fromNow() to return in the following format [number] seconds ago.
However, currently, it will only return "a few seconds ago".