### PR TITLE
document isDuration method

### DIFF
--- a/docs/moment/08-durations/15-is-a-duration.md
+++ b/docs/moment/08-durations/15-is-a-duration.md
@@ -1,0 +1,17 @@
+---
+title: Is a Duration
+version: 1.6.0
+signature: |
+  moment.isDuration(obj);
+---
+
+
+To check if a variable is a moment duration object, use `moment.isDuration()`.
+
+```javascript
+moment.isDuration() // false
+moment.isDuration(new Date()) // false
+moment.isDuration(moment()) // false
+moment.isDuration(moment.duration()) // true
+moment.isDuration(moment.duration(2, 'minutes')) // true
+```


### PR DESCRIPTION
This method is available but has not been documented. I had a use case for it and since it's been in moment since `1.6.0` I assume it's appropriate to rely on it? 

This adds documentation in similar style to the `moment#isMoment` method.

Original issue: https://github.com/moment/moment/issues/2568