### PR TITLE
Update docs to say when two digit = 68. It is 2068

### DIFF
--- a/docs/moment/01-parsing/03-string-format.md
+++ b/docs/moment/01-parsing/03-string-format.md
@@ -127,4 +127,4 @@ moment('2012-10-14', 'YYYY-MM-DD', 'fr', true);
 
 #### Parsing two digit years
 
-By default, two digit years above 68 are assumed to be in the 1900's and years below 68 are assumed to be in the 2000's. This can be changed by replacing the `moment.parseTwoDigitYear` method.
+By default, two digit years above 68 are assumed to be in the 1900's and years below and including 68 are assumed to be in the 2000's. This can be changed by replacing the `moment.parseTwoDigitYear` method.


### PR DESCRIPTION
What happen's when two digit is 68? This was unspecified in the documentation.

See:
https://github.com/moment/moment/blob/f3fbef9d9875bbff340b527dbe3f1c447a942f69/moment.js#L900