### PR TITLE
Fix spelling errors for ms-my

### DIFF
--- a/data/locale.js
+++ b/data/locale.js
@@ -53,7 +53,7 @@ var locales = {
     'mk'     : 'Macedonian',
     'ml'     : 'Malayalam',
     'mr'     : 'Marathi',
-    'ms-my'  : 'Bahasa Malayu',
+    'ms-my'  : 'Bahasa Melayu (Malaysia)',
     'my'     : 'Burmese',
     'nb'     : 'Norwegian',
     'ne'     : 'Nepalese',


### PR DESCRIPTION
Updated from 'Bahasa Malayu' to 'Bahasa Melayu (Malaysia)'