### PR TITLE
Changed title to 'Is Same or After'

### DIFF
--- a/docs/moment/05-query/05-is-same-or-after.md
+++ b/docs/moment/05-query/05-is-same-or-after.md
@@ -1,5 +1,5 @@
 ---
-title: Is Same Or After
+title: Is Same or After
 version: 2.10.7
 signature: |
   moment().isSameOrAfter(Moment|String|Number|Date|Array);


### PR DESCRIPTION
Changed title to 'Is Same or After' instead of 'Is Same or After'. Should match 'Is Same or Before'.