### PR TITLE
Fix a typo

### DIFF
--- a/docs/moment/01-parsing/09-date.md
+++ b/docs/moment/01-parsing/09-date.md
@@ -13,4 +13,4 @@ var day = new Date(2011, 9, 16);
 var dayWrapper = moment(day);
 ```
 
-This clones `Date` object; further changes to the `Date` won't affect the `Moment`, and vice-versa.
+This clones the `Date` object; further changes to the `Date` won't affect the `Moment`, and vice-versa.


### PR DESCRIPTION
Need an article before "`Date` object".