### PR TITLE
Locale and warning related minor updates

### DIFF
--- a/docs/moment/07-customization/00-intro.md
+++ b/docs/moment/07-customization/00-intro.md
@@ -11,16 +11,6 @@ moment.locale('en-my-settings', {
 });
 ```
 
-However, you can also overwrite an existing locale that has been loaded as well.
-
-```javascript
-moment.locale('en', {
-    // customizations
-});
-```
-
-Any settings that are not defined are inherited from the default english settings.
-
 You can remove a previously defined locale by passing `null` as the second argument.
 The deleted locale will no longer be available for use.
 
@@ -55,3 +45,5 @@ To revert an update use:
 ```javascript
 moment.updateLocale('en', null);
 ```
+
+**2.12.0** deprecated using ``moment.locale()`` to change an existing locale. Use ``moment.updateLocale()`` instead.

--- a/docs/moment/07-customization/01-month-names.md
+++ b/docs/moment/07-customization/01-month-names.md
@@ -2,7 +2,14 @@
 title: Month Names
 version: 1.0.0
 signature: |
-  // From 2.8.1 onward
+  // From 2.12.0 onward
+  moment.updateLocale('en', {
+      months : String[]
+  });
+  moment.updateLocale('en', {
+      months : Function
+  });
+  // From 2.8.1 to 2.11.2
   moment.locale('en', {
       months : String[]
   });
@@ -23,7 +30,7 @@ signature: |
 `Locale#months` should be an array of the month names.
 
 ```javascript
-moment.locale('en', {
+moment.updateLocale('en', {
     months : [
         "January", "February", "March", "April", "May", "June", "July",
         "August", "September", "October", "November", "December"
@@ -34,7 +41,7 @@ moment.locale('en', {
 If you need more processing to calculate the name of the month, (for example, if there is different grammar for different formats), `Locale#months` can be a function with the following signature. It should always return a month name.
 
 ```javascript
-moment.locale('en', {
+moment.updateLocale('en', {
     months : function (momentToFormat, format) {
         // momentToFormat is the moment currently being formatted
         // format is the formatting string

--- a/docs/moment/07-customization/02-month-abbreviations.md
+++ b/docs/moment/07-customization/02-month-abbreviations.md
@@ -2,7 +2,14 @@
 title: Month Abbreviations
 version: 1.0.0
 signature: |
-  // From 2.8.1 onward
+  // From 2.12.0 onward
+  moment.updateLocale('en', {
+      monthsShort : String[]
+  });
+  moment.updateLocale('en', {
+      monthsShort : Function
+  });
+  // From 2.8.1 to 2.11.2
   moment.locale('en', {
       monthsShort : String[]
   });
@@ -23,7 +30,7 @@ signature: |
 `Locale#monthsShort` should be an array of the month abbreviations.
 
 ```javascript
-moment.locale('en', {
+moment.updateLocale('en', {
     monthsShort : [
         "Jan", "Feb", "Mar", "Apr", "May", "Jun",
         "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
@@ -34,7 +41,7 @@ moment.locale('en', {
 Like `Locale#months`, `Locale#monthsShort` can be a callback function as well.
 
 ```javascript
-moment.locale('en', {
+moment.updateLocale('en', {
     monthsShort : function (momentToFormat, format) {
         if (/^MMMM/.test(format)) {
             return nominative[momentToFormat.month()];

--- a/docs/moment/07-customization/03-weekday-names.md
+++ b/docs/moment/07-customization/03-weekday-names.md
@@ -2,7 +2,14 @@
 title: Weekday Names
 version: 1.0.0
 signature: |
-  // From version 2.8.1 onward
+  // From version 2.12.0 onward
+  moment.updateLocale('en', {
+      weekdays : String[]
+  });
+  moment.updateLocale('en', {
+      weekdays : Function
+  });
+  // From version 2.8.1 to 2.11.2
   moment.locale('en', {
       weekdays : String[]
   });
@@ -24,7 +31,7 @@ signature: |
 `Locale#weekdays` should be an array of the weekdays names.
 
 ```javascript
-moment.locale('en', {
+moment.updateLocale('en', {
     weekdays : [
         "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
     ]

--- a/docs/moment/07-customization/04-weekday-abbreviations.md
+++ b/docs/moment/07-customization/04-weekday-abbreviations.md
@@ -2,7 +2,14 @@
 title: Weekday Abbreviations
 version: 1.0.0
 signature: |
-  // From 2.8.1 onward
+  // From 2.12.0 onward
+  moment.updateLocale('en', {
+      weekdaysShort : String[]
+  });
+  moment.updateLocale('en', {
+      weekdaysShort : Function
+  });
+  // From 2.8.1 to 2.11.2
   moment.locale('en', {
       weekdaysShort : String[]
   });
@@ -23,7 +30,7 @@ signature: |
 `Locale#weekdaysShort` should be an array of the weekdays abbreviations.
 
 ```javascript
-moment.locale('en', {
+moment.updateLocale('en', {
     weekdaysShort : ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
 });
 ```
@@ -31,7 +38,7 @@ moment.locale('en', {
 `Locale#weekdaysShort` can be a callback function as well.
 
 ```javascript
-moment.locale('en', {
+moment.updateLocale('en', {
     weekdaysShort : function (momentToFormat, format) {
         return weekdaysShort[momentToFormat.day()];
     }

--- a/docs/moment/07-customization/05-weekday-min.md
+++ b/docs/moment/07-customization/05-weekday-min.md
@@ -2,7 +2,15 @@
 title: Minimal Weekday Abbreviations
 version: 1.7.0
 signature: |
-  // From 2.8.1 onward
+  // From 2.12.0 onward
+  moment.updateLocale('en', {
+      weekdaysMin : String[]
+  });
+  moment.updateLocale('en', {
+      weekdaysMin : Function
+  });
+
+  // From 2.8.1 to 2.11.2
   moment.locale('en', {
       weekdaysMin : String[]
   });
@@ -23,7 +31,7 @@ signature: |
 `Locale#weekdaysMin` should be an array of two letter weekday abbreviations. The purpose of these is for things like calendar pickers, thus they should be as small as possible.
 
 ```javascript
-moment.locale('en', {
+moment.updateLocale('en', {
     weekdaysMin : ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
 });
 ```
@@ -31,7 +39,7 @@ moment.locale('en', {
 `Locale#weekdaysMin` can be a callback function as well.
 
 ```javascript
-moment.locale('en', {
+moment.updateLocale('en', {
     weekdaysMin : function (momentToFormat, format) {
         return weekdaysMin[momentToFormat.day()];
     }

--- a/docs/moment/07-customization/06-long-date-formats.md
+++ b/docs/moment/07-customization/06-long-date-formats.md
@@ -2,7 +2,15 @@
 title: Long Date Formats
 version: 1.1.0
 signature: |
-  // From 2.8.1 onward
+  // From 2.12.0 onward
+  moment.updateLocale('en', {
+      weekdaysMin : String[]
+  });
+  moment.updateLocale('en', {
+      weekdaysMin : Function
+  });
+
+  // From 2.8.1 to 2.11.2
   moment.locale('en', {
       longDateFormat : Object
   });
@@ -17,7 +25,7 @@ signature: |
 `Locale#longDateFormat` should be an object containing a key/value pair for each long date format `L LL LLL LLLL LT LTS`. `LT` should be the time format, and is also used for `moment#calendar`.
 
 ```javascript
-moment.locale('en', {
+moment.updateLocale('en', {
     longDateFormat : {
         LT: "h:mm A",
         LTS: "h:mm:ss A",
@@ -36,7 +44,7 @@ moment.locale('en', {
 You can eliminate the lowercase `l` tokens and they will be created automatically by replacing long tokens with the short token variants.
 
 ```javascript
-moment.locale('en', {
+moment.updateLocale('en', {
     longDateFormat : {
         LT: "h:mm A",
         LTS: "h:mm:ss A",

--- a/docs/moment/07-customization/07-relative-time.md
+++ b/docs/moment/07-customization/07-relative-time.md
@@ -2,7 +2,11 @@
 title: Relative Time
 version: 1.0.0
 signature: |
-  // From 2.8.1 onward
+  // From 2.12.0 onward
+  moment.updateLocale('en', {
+      relativeTime : Object
+  });
+  // From 2.8.1 to 2.11.2
   moment.locale('en', {
       relativeTime : Object
   });
@@ -17,7 +21,7 @@ signature: |
 `Locale#relativeTime` should be an object of the replacement strings for `moment#from`.
 
 ```javascript
-moment.locale('en', {
+moment.updateLocale('en', {
     relativeTime : {
         future: "in %s",
         past:   "%s ago",

--- a/docs/moment/07-customization/08-am-pm.md
+++ b/docs/moment/07-customization/08-am-pm.md
@@ -2,7 +2,11 @@
 title: AM/PM
 version: 1.6.0
 signature: |
-  // From 2.8.1 onward
+  // From 2.12.0 onward
+  moment.updateLocale('en', {
+      meridiem : Function
+  });
+  // From 2.8.1 to 2.11.2
   moment.locale('en', {
       meridiem : Function
   });
@@ -19,7 +23,7 @@ If your locale uses 'am/pm', `Locale#meridiem` can be omitted, as those values a
 If your locale needs any different computation for am/pm, `Locale#meridiem` should be a callback function that returns the correct string based on hour, minute, and upper/lowercase.
 
 ```javascript
-moment.locale('zh-cn', {
+moment.updateLocale('zh-cn', {
     meridiem : function (hour, minute, isLowercase) {
         if (hour < 9) {
             return "早上";
@@ -39,7 +43,7 @@ moment.locale('zh-cn', {
 Before version **1.6.0**, `Locale#meridiem` was a map of upper and lowercase versions of am/pm.
 
 ```javascript
-moment.locale('en', {
+moment.updateLocale('en', {
     meridiem : {
         am : 'am',
         AM : 'AM',

--- a/docs/moment/07-customization/09-am-pm-parsing.md
+++ b/docs/moment/07-customization/09-am-pm-parsing.md
@@ -2,7 +2,13 @@
 title: AM/PM Parsing
 version: 2.1.0
 signature: |
-  // From 2.8.1 onward
+  // From 2.12.0 onward
+  moment.updateLocale('en', {
+      meridiemParse : RegExp
+      isPM : Function
+  });
+
+  // From 2.8.1 to 2.11.2
   moment.locale('en', {
       meridiemParse : RegExp
       isPM : Function
@@ -19,7 +25,7 @@ signature: |
 `Locale#isPM` should return true if the input string is past 12 noon. This is used in parsing the `a A` tokens.
 
 ```javascript
-moment.locale('en', {
+moment.updateLocale('en', {
     isPM : function (input) {
         return ((input + '').toLowerCase()[0] === 'p');
     }
@@ -29,7 +35,7 @@ moment.locale('en', {
 To configure what strings should be parsed as input, set the `meridiemParse` property.
 
 ```javascript
-moment.locale('en', {
+moment.updateLocale('en', {
     meridiemParse : /[ap]\.?m?\.?/i
 });
 ```

--- a/docs/moment/07-customization/10-calendar.md
+++ b/docs/moment/07-customization/10-calendar.md
@@ -2,7 +2,11 @@
 title: Calendar
 version: 1.3.0
 signature: |
-  // From 2.8.1 onward
+  // From 2.12.0 onward
+  moment.updateLocale('en', {
+      calendar : Object
+  });
+  // From 2.8.1 to 2.11.2
   moment.locale('en', {
       calendar : Object
   });

--- a/docs/moment/07-customization/11-ordinal.md
+++ b/docs/moment/07-customization/11-ordinal.md
@@ -2,7 +2,11 @@
 title: Ordinal
 version: 1.0.0
 signature: |
-  // From 2.8.1 onward
+  // From 2.12.0 onward
+  moment.updateLocale('en', {
+      ordinal : Function
+  });
+  // From 2.8.1 to 2.11.2
   moment.locale('en', {
       ordinal : Function
   });
@@ -17,7 +21,7 @@ signature: |
 `Locale#ordinal` should be a function that returns the ordinal for a given number.
 
 ```javascript
-moment.locale('en', {
+moment.updateLocale('en', {
     ordinal : function (number, token) {
         var b = number % 10;
         var output = (~~ (number % 100 / 10) === 1) ? 'th' :

--- a/guides/moment/00-lib-concepts/01-mutability.md
+++ b/guides/moment/00-lib-concepts/01-mutability.md
@@ -19,5 +19,5 @@ As you can see, adding one week mutated ``a``. To avoid situations like that, cl
 var a = moment('2016-01-01'); 
 var b = a.clone().add(1, 'week'); 
 a.format();
-"2016-01-08T00:00:00-06:00"
+"2016-01-01T00:00:00-06:00"
 ```

--- a/guides/moment/02-warnings/01-js-date.md
+++ b/guides/moment/02-warnings/01-js-date.md
@@ -9,3 +9,5 @@ This deprecation warning is thrown when no known format is found for a date pass
 To work around this issue, specify a format for the string being passed to ``moment()``.
 
 <a href="~/docs/#/parsing">See the parsing docs for more information.</a>
+
+<a href="https://github.com/moment/moment/issues/1407" target="_blank">View original GitHub issue</a>

--- a/guides/moment/02-warnings/02-define-locale.md
+++ b/guides/moment/02-warnings/02-define-locale.md
@@ -8,3 +8,5 @@ moment.defineLocale(localeName, config) should only be used for creating a new l
 
 This deprecation warning is thrown when you attempt to change an existing locale using the defineLocale function. 
 Doing this will result in unexpected behavior related to property inheritance. moment.updateLocale will properly replace properties on an existing locale.
+
+<a href="https://github.com/moment/moment/pull/2774" target="_blank">View original pull request</a>

--- a/guides/moment/02-warnings/05-min-max.md
+++ b/guides/moment/02-warnings/05-min-max.md
@@ -29,3 +29,5 @@ moment('2016-01-01').max('2016-02-01').format()
 moment.min(moment('2016-01-01'), moment('2016-02-01')).format()
 "2016-01-01T00:00:00-06:00"
 ```
+
+<a href="https://github.com/moment/moment/issues/1548" target="_blank">See original GitHub issue.</a>

--- a/guides/moment/02-warnings/06-zone.md
+++ b/guides/moment/02-warnings/06-zone.md
@@ -8,8 +8,10 @@ use moment().utcOffset instead.
 ```
 
 This deprecation was made for purposes of clarity. 
-The result of moment().zone() is an integer that indicates the number of minutes that a given moment is offset from UTC, with the sign inverted (US moments result in a positive value). 
-Using zone(number) to set the offset will set the offset on the date, also using an inverted sign.
+
+The result of ``moment().zone()`` is an integer that indicates the number of minutes that a given moment is offset from UTC, with the sign inverted (US moments result in a positive value). 
+
+Using ``moment().zone(number)`` to set the offset will set the offset on the date, also using an inverted sign.
 
 Because a time zone is not the same thing as an offset, the name was changed to utcOffset. At that time the sign was corrected to reflect the actual direction of the UTC offset.
 
@@ -25,3 +27,5 @@ moment().zone(420)
 moment().utcOffset(-420)
 ```
 [For more information on time zone vs offset, see the Time Zone vs Offset guide.](#/lib-concepts/timezone-offset/)
+
+<a href="https://github.com/moment/moment/issues/1779" target="_blank">View original GitHub issue.</a>


### PR DESCRIPTION
Removes documentation regarding updating locales using moment.locale closing moment/moment#3043

Update warnings to reference original GitHub issues. 

Minor formatting updates.