### PR TITLE
Fix edit links for guides

### DIFF
--- a/data/docs.js
+++ b/data/docs.js
@@ -32,7 +32,7 @@ module.exports = function (type, root) {
 
 		item.body = data.content;
 		item.slug = groupSlug + '/' + itemSlug;
-		item.edit = 'https://github.com/moment/momentjs.com/blob/master/docs/' + root + '/' + groupPath + '/' + itemPath + '.md';
+		item.edit = 'https://github.com/moment/momentjs.com/blob/master/' + type + '/' + root + '/' + groupPath + '/' + itemPath + '.md';
 	});
 
 	return groups;


### PR DESCRIPTION
This fixes the edit links for the guides section.

Before:
https://github.com/moment/momentjs.com/blob/master/docs/moment/01-parsing/03-strict-mode.md

After:
https://github.com/moment/momentjs.com/blob/master/guides/moment/01-parsing/03-strict-mode.md