### PR TITLE
Issue 227 Docs for local and utc methods need rewording

### DIFF
--- a/docs/moment/03-manipulating/07-local.md
+++ b/docs/moment/03-manipulating/07-local.md
@@ -6,7 +6,7 @@ signature: |
 ---
 
 
-Sets a flag on the original moment to internally use `Date#get*` and `Date#set*` instead of `Date#getUTC*` and `Date#setUTC*`.
+Sets a flag on the original moment to use local time to  parse or display a moment instead of UTC.
 
 ```javascript
 var a = moment.utc([2011, 0, 1, 8]);

--- a/docs/moment/03-manipulating/07-local.md
+++ b/docs/moment/03-manipulating/07-local.md
@@ -6,7 +6,7 @@ signature: |
 ---
 
 
-Sets a flag on the original moment to use local time to  parse or display a moment instead of UTC.
+Sets a flag on the original moment to use local time to parse or display a moment instead of UTC.
 
 ```javascript
 var a = moment.utc([2011, 0, 1, 8]);

--- a/docs/moment/03-manipulating/08-utc.md
+++ b/docs/moment/03-manipulating/08-utc.md
@@ -6,7 +6,7 @@ signature: |
 ---
 
 
-Sets a flag on the original moment to internally use `Date#getUTC*` and `Date#setUTC*` instead of `Date#get*` and `Date#set*`.
+Sets a flag on the original moment to use UTC to parse or display a moment instead of local time.
 
 ```javascript
 var a = moment([2011, 0, 1, 8]);


### PR DESCRIPTION
Rewrote the text removing reference to internal use, and hopefully describing their use.

Grabbed this issue as it was marked up-for-grabs. Hope was ok to do so.