### PR TITLE
Update 01-parsing-in-zone.md

### DIFF
--- a/docs/moment-timezone/01-using-timezones/01-parsing-in-zone.md
+++ b/docs/moment-timezone/01-using-timezones/01-parsing-in-zone.md
@@ -6,7 +6,7 @@ signature: |
 
 
 The `moment.tz` constructor takes all the same arguments as the `moment`
-constructor, but uses the last argument as a time zone identifier.
+constructor, but uses the last argument as a [time zone identifier] (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
 ```js
 var a = moment.tz("2013-11-18 11:55", "America/Toronto");


### PR DESCRIPTION
Provided a wikipedia link (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to 01-parsing-in-zone.md such that developers unfamiliar with timezones can easily find the correct string argument to pass to the function