### PR TITLE
01-parsing-in-zone.md - Removed markdown identifier and replaced with <a></a>

### DIFF
--- a/docs/moment-timezone/01-using-timezones/01-parsing-in-zone.md
+++ b/docs/moment-timezone/01-using-timezones/01-parsing-in-zone.md
@@ -6,7 +6,7 @@ signature: |
 
 
 The `moment.tz` constructor takes all the same arguments as the `moment`
-constructor, but uses the last argument as a [time zone identifier] (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+constructor, but uses the last argument as a <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones" target="_blank">time zone identifier</a>.
 
 ```js
 var a = moment.tz("2013-11-18 11:55", "America/Toronto");


### PR DESCRIPTION
Sorry it was my first time contributing.  I was too confident that the markdown identifier approach would work after seeing how one of the doc pages used that, but it turned out the live website was not showing what I was expecting.

I made the change again and ran it on my local machine.  Now the hyperlink should work. 