### PR TITLE
Update documentation for clone

### DIFF
--- a/docs/moment/01-parsing/12-moment-clone.md
+++ b/docs/moment/01-parsing/12-moment-clone.md
@@ -6,7 +6,7 @@ signature: |
 ---
 
 
-All moments are mutable. If you want a clone of a moment, you can do so explicitly or implicitly.
+All moments are mutable. If you want a clone of a moment, you can do so implicitly or explicitly.
 
 Calling `moment()` on a moment will clone it.
 


### PR DESCRIPTION
Swap "implicitly" and "explicitly" to match examples order.