### PR TITLE
Make second hand on main logo sweep smoothly.

### DIFF
--- a/assets/js/core-home.js
+++ b/assets/js/core-home.js
@@ -15,7 +15,7 @@
 
     function updateClock(){
         var now = moment(),
-            second = now.seconds() * 6,
+            second = (now.second() + now.millisecond()/1000) * 6,
             minute = now.minutes() * 6 + second / 60,
             hour = ((now.hours() % 12) / 12) * 360 + 90 + minute / 12;
 
@@ -65,9 +65,14 @@
         this.el.html(output.join('\n'));
     };
 
+    function animateClock() {
+        window.requestAnimationFrame(function() {
+            updateClock();
+            setTimeout(animateClock, 100);
+        });
+    }
 
     function timedUpdate () {
-        updateClock();
         updateSnippets();
         setTimeout(timedUpdate, 1000);
     }
@@ -76,6 +81,7 @@
         snippets.push(new Snippet($(this)));
     });
 
+    animateClock();
     timedUpdate();
 
     $(document).on('click', '[data-locale]', function(){


### PR DESCRIPTION
The main clock logo currently has a seconds hand that ticks. This PR changes it so that it sweeps smoothly (like an analogue watch).

Benefits:
- I think it looks a lot more impressive
- It demonstrates the `millisecond` function call in the library (along with `second`).

It uses `requestAnimationFrame`, and a hard limit of 10 fps to limit CPU usage.