### PR TITLE
Fix syntax errors in WIP 2.14.0 docs

### DIFF
--- a/docs/moment/04-displaying/06-calendar-time.md
+++ b/docs/moment/04-displaying/06-calendar-time.md
@@ -69,5 +69,6 @@ moment().calendar(null, {
       return '[Happened Today]';
     }
     /* ... */
+  }
 });
 ```

--- a/docs/moment/07-customization/01-month-names.md
+++ b/docs/moment/07-customization/01-month-names.md
@@ -76,5 +76,5 @@ moment.updateLocale('en', {
          standalone: 'sausis_vasaris_kovas_balandis_gegužė_birželis_liepa_rugpjūtis_rugsėjis_spalis_lapkritis_gruodis'.split('_'),
          isFormat: /D[oD]?(\[[^\[\]]*\]|\s+)+MMMM?|MMMM?(\[[^\[\]]*\]|\s+)+D[oD]?/  // from 2.14.0
     }
-}
+});
 ```


### PR DESCRIPTION
Please note that this is not to master but to the 2.14.0 branch, which currently has a PR open (#326).

The only failures remaining now are because `moment.relativeTimeThreshold` is not yet defined, but that will go away once v2.14.0 has been released. Another option is to `npm install --save moment/moment` so that the latest commits to `master` on `moment` would be included, but I've held off that in case it's not what y'all would want.