### PR TITLE
In Travis, only run continuous deploy script after merge to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-script: bash ./deploy.sh
+script: ./compile.sh && npm run doctest
+after_success: "[[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]] && bash ./deploy.sh"
 env:
   global:
   - GH_REF: github.com/moment/momentjs.com.git


### PR DESCRIPTION
I think this should fix #339. 

We could also split up `deploy.sh` so that we don't bother repeating the compile prior to the deploy, but I didn't want to change the semantics of that script without discussing it first.  😉 