### PR TITLE
Fix code snippets updating every second (fixes #158)

### DIFF
--- a/assets/js/core-home.js
+++ b/assets/js/core-home.js
@@ -68,7 +68,6 @@
 
     function timedUpdate () {
         updateClock();
-        updateSnippets();
         setTimeout(timedUpdate, 1000);
     }
 
@@ -77,6 +76,7 @@
     });
 
     timedUpdate();
+    updateSnippets();
 
     $(document).on('click', '[data-locale]', function(){
         var dom = $(this);


### PR DESCRIPTION
#158 The comments in the code snippets were set to update every second. This prevented the snippets to be copied from the browser.

Changed the behavior to update the comments only once during page render.