### PR TITLE
Document locale as array in constructor functions

### DIFF
--- a/docs/moment/01-parsing/03-string-format.md
+++ b/docs/moment/01-parsing/03-string-format.md
@@ -4,8 +4,10 @@ version: 1.0.0
 signature: |
   moment(String, String);
   moment(String, String, String);
+  moment(String, String, String[]);
   moment(String, String, Boolean);
   moment(String, String, String, Boolean);
+  moment(String, String, String[], Boolean);
 ---
 
 

--- a/docs/moment/01-parsing/04-string-formats.md
+++ b/docs/moment/01-parsing/04-string-formats.md
@@ -2,7 +2,8 @@
 title: String + Formats
 version: 1.0.0
 signature: |
-  moment(String, String[], String, Boolean);
+  moment(String, String[], [String], [Boolean]);
+  moment(String, String[], [String[]], [Boolean]);
 ---
 
 

--- a/docs/moment/01-parsing/05-special-formats.md
+++ b/docs/moment/01-parsing/05-special-formats.md
@@ -3,7 +3,9 @@ title: Special Formats
 version: 2.7.0
 signature: |
   moment(String, moment.CUSTOM_FORMAT, [String], [Boolean]);
+  moment(String, moment.CUSTOM_FORMAT, [String[]], [Boolean]);
   moment(String, [..., moment.ISO_8601, ...], [String], [Boolean]);
+  moment(String, [..., moment.ISO_8601, ...], [String[]], [Boolean]);
 ---
 
 [ISO-8601](http://en.wikipedia.org/wiki/ISO_8601) is a standard for time and duration display. Moment already supports parsing iso-8601 strings, but this can be specified explicitly in the format/list of formats when constructing a moment.

--- a/docs/moment/01-parsing/13-utc.md
+++ b/docs/moment/01-parsing/13-utc.md
@@ -9,6 +9,7 @@ signature: |
   moment.utc(String, String);
   moment.utc(String, String[]);
   moment.utc(String, String, String);
+  moment.utc(String, String, String[]);
   moment.utc(Moment);
   moment.utc(Date);
 ---

--- a/docs/moment/06-i18n/02-instance-locale.md
+++ b/docs/moment/06-i18n/02-instance-locale.md
@@ -4,6 +4,7 @@ version: 1.7.0
 signature: |
   // From version 2.8.1 onward
   moment().locale(String);
+  moment().locale(String[]);
 
   // Deprecated version 2.8.1
   moment().lang(String);


### PR DESCRIPTION
Add definitions with array for locale, to fix #343