### PR TITLE
Capitalize UTC more consistently

### DIFF
--- a/docs/moment/03-manipulating/08-utc.md
+++ b/docs/moment/03-manipulating/08-utc.md
@@ -15,7 +15,7 @@ a.utc();
 a.hours(); // 16 UTC
 ```
 
-Utc can also be used to convert out of a fixed offset mode:
+UTC can also be used to convert out of a fixed offset mode:
 
 ```javascript
 moment.parseZone('2016-05-03T22:15:01+02:00').utc().format(); //"2016-05-03T20:15:01Z"

--- a/docs/moment/03-manipulating/09-utc-offset.md
+++ b/docs/moment/03-manipulating/09-utc-offset.md
@@ -1,24 +1,24 @@
 ---
-title: UTC Offset
+title: UTC offset
 version: 2.9.0+
 signature: |
   moment().utcOffset();
   moment().utcOffset(Number|String);
 ---
 
-Get the utc offset in minutes.
+Get the UTC offset in minutes.
 
 **NOTE**: Unlike [`moment.fn.zone`](/docs/#/manipulating/timezone-offset/) this
 function returns the real offset from UTC, not the reverse offset (as returned
 by `Date.prototype.getTimezoneOffset`).
 
-Getting the utcOffset of the current object:
+Getting the `utcOffset` of the current object:
 
 ```javascript
 moment().utcOffset(); // (-240, -120, -60, 0, 60, 120, 240, etc.)
 ```
 
-Setting the utc offset by supplying minutes. Note that once you set an offset,
+Setting the UTC offset by supplying minutes. Note that once you set an offset,
 it's fixed and won't change on its own (i.e there are no DST rules). If you want
 an actual time zone -- time in a particular location, like
 `America/Los_Angeles`, consider [moment-timezone](/timezone/).
@@ -35,7 +35,7 @@ moment().utcOffset(8);  // set hours offset
 moment().utcOffset(480);  // set minutes offset (8 * 60)
 ```
 
-It is also possible to set the utc offset from a string.
+It is also possible to set the UTC offset from a string.
 
 ```javascript
 // these are equivalent
@@ -46,7 +46,7 @@ moment().utcOffset(480);
 
 `moment#utcOffset` will search the string for the first match of `+00:00 +0000
 -00:00 -0000`, so you can even pass an ISO8601 formatted string and the moment
-will be changed to that utc offset.
+will be changed to that UTC offset.
 
 Note that the string is required to start with the `+` or `-` character.  Passing a string that
 does not start with `+` or `-` will be interpreted as if it were `"+00:00"`.


### PR DESCRIPTION
Change some occurrences of *Utc* and *utc* to *UTC* in the docs.