### PR TITLE
Change "loaded" to "available"

### DIFF
--- a/docs/moment-timezone/04-data-loading/05-getting-zone-names.md
+++ b/docs/moment-timezone/04-data-loading/05-getting-zone-names.md
@@ -4,7 +4,7 @@ signature: |
   moment.tz.names(); // String[]
 ---
 
-To get a list of all the loaded time zone names, use `moment.tz.names`.
+To get a list of all available time zone names, use `moment.tz.names`.
 
 ```js
 moment.tz.names(); // ["Africa/Abidjan", "Africa/Accra", "Africa/Addis_Ababa", ...]


### PR DESCRIPTION
After skimming the subsections before this one (Adding a Zone, Adding a Link, Loading a Data Bundle, & Checking Zone Existence), seeing "loaded" here made me think I had to do something on my end to somehow load the zones before being able to get the full list. I think "available" says it better.