### PR TITLE
Use singular form of time period

### DIFF
--- a/docs/moment/02-get-set/03-minute.md
+++ b/docs/moment/02-get-set/03-minute.md
@@ -11,4 +11,4 @@ signature: |
 
 Gets or sets the minutes.
 
-Accepts numbers from 0 to 59. If the range is exceeded, it will bubble up to the hours.
+Accepts numbers from 0 to 59. If the range is exceeded, it will bubble up to the hour.


### PR DESCRIPTION
Just noticed this tiny discrepancy in the docs. Thanks for the awesome library! :cat: