### PR TITLE
Fix typo Javanese on locale.js

### DIFF
--- a/data/locale.js
+++ b/data/locale.js
@@ -218,7 +218,7 @@ module.exports =[
     },
     {
         "abbr": "jv",
-        "name": "Japanese"
+        "name": "Javanese"
     },
     {
         "abbr": "kk",


### PR DESCRIPTION
It's complicated...
<img width="204" alt="2016-09-25 20 24 21" src="https://cloud.githubusercontent.com/assets/2628239/18815010/779a1410-835e-11e6-9271-62bf0a410e0e.png">

It's something wrong: Ja**v**anese is not Ja**p**anese.
https://en.wikipedia.org/wiki/Javanese_language

Related: https://github.com/moment/moment/pull/3466