### PR TITLE
Update 07-unix-timestamp-milliseconds.md

### DIFF
--- a/docs/moment/01-parsing/07-unix-timestamp-milliseconds.md
+++ b/docs/moment/01-parsing/07-unix-timestamp-milliseconds.md
@@ -2,11 +2,11 @@
 title: Unix Timestamp (milliseconds)
 version: 1.0.0
 signature: |
-  moment(Number);
+  moment(value);
 ---
 
 
-Similar to `new Date(Number)`, you can create a moment by passing an integer value representing the number of *milliseconds* since the Unix Epoch (Jan 1 1970 12AM UTC).
+Similar to `new Date(value)`, you can create a moment by passing an integer value representing the number of *milliseconds* since the Unix Epoch (Jan 1 1970 12AM UTC).
 
 ```javascript
 var day = moment(1318781876406);


### PR DESCRIPTION
'Number' induces in error by creating ambiguity with the Number object.