### PR TITLE
docs/moment-timezone: Document moment#tz() returning the zone name

### DIFF
--- a/docs/moment-timezone/01-using-timezones/03-converting-to-zone.md
+++ b/docs/moment-timezone/01-using-timezones/03-converting-to-zone.md
@@ -22,3 +22,15 @@ m.startOf("day").format();      // 2013-11-18T00:00:00-05:00
 m.tz("Europe/Berlin").format(); // 2013-11-18T06:00:00+01:00
 m.startOf("day").format();      // 2013-11-18T00:00:00+01:00
 ```
+
+Without an argument, `moment#tz` returns:
+
+* the time zone name assigned to the moment instance or
+* `undefined` if a time zone has not been set.
+
+```javascript
+var m = moment.tz("2013-11-18 11:55", "America/Toronto");
+m.tz();  // America/Toronto
+var m = moment.tz("2013-11-18 11:55");
+m.tz() === undefined;  // true
+```


### PR DESCRIPTION
This seems to have been the behavior since moment/moment-timezone@fb76dd574 (Adding links, 2013-05-18, v0.0.1).