### PR TITLE
Correct typo on localeData.week() in docs/08-locale-data.md

### DIFF
--- a/docs/moment/06-i18n/08-locale-data.md
+++ b/docs/moment/06-i18n/08-locale-data.md
@@ -19,7 +19,7 @@ signature: |
   localeData.ordinal()
   localeData.preparse()
   localeData.postformat()
-  localeData.weeks()
+  localeData.week()
   localeData.invalidDate()
   localeData.firstDayOfWeek()
   localeData.firstDayOfYear()


### PR DESCRIPTION
Fixes https://github.com/moment/moment/issues/3491

----

`localeData.weeks()` is a typo in the method signature - the correct method is `localeData.week()`, as stated below it:

```js
localeData.week(aMoment);  // returns week-of-year of aMoment
```