### PR TITLE
Added "download" attribute to Moment download links

### DIFF
--- a/pages/moment-timezone/index.hbs
+++ b/pages/moment-timezone/index.hbs
@@ -21,26 +21,26 @@ scripts :
 <div class="builds">
 	<div class="builds-download">
 		<h3>Download</h3>
-		<a class="builds-button builds-button-source" href="/downloads/moment-timezone.js">
+		<a class="builds-button builds-button-source" href="/downloads/moment-timezone.js" download>
 			moment-timezone.js
 		</a>
-		<a class="builds-button builds-button-gzipped" href="/downloads/moment-timezone.min.js">
+		<a class="builds-button builds-button-gzipped" href="/downloads/moment-timezone.min.js" download>
 			moment-timezone.min.js
 			<span class="filesize">{{toKb size.moment_timezone_min.gzip }}</span>
 		</a>
 
-		<a class="builds-button builds-button-source" href="/downloads/moment-timezone-with-data-2010-2020.js">
+		<a class="builds-button builds-button-source" href="/downloads/moment-timezone-with-data-2010-2020.js" download>
 			moment-timezone-2010-2020.js
 		</a>
-		<a class="builds-button builds-button-gzipped" href="/downloads/moment-timezone-with-data-2010-2020.min.js">
+		<a class="builds-button builds-button-gzipped" href="/downloads/moment-timezone-with-data-2010-2020.min.js" download>
 			moment-timezone-2010-2020.min.js
 			<span class="filesize">{{toKb size.moment_timezone_with_data_2010_2020_min.gzip }}</span>
 		</a>
 
-		<a class="builds-button builds-button-source" href="/downloads/moment-timezone-with-data.js">
+		<a class="builds-button builds-button-source" href="/downloads/moment-timezone-with-data.js" download>
 			moment-timezone-all-years.js
 		</a>
-		<a class="builds-button builds-button-gzipped" href="/downloads/moment-timezone-with-data.min.js">
+		<a class="builds-button builds-button-gzipped" href="/downloads/moment-timezone-with-data.min.js" download>
 			moment-timezone-all-years.min.js
 			<span class="filesize">{{toKb size.moment_timezone_with_data_min.gzip }}</span>
 		</a>

--- a/pages/moment/index.hbs
+++ b/pages/moment/index.hbs
@@ -26,17 +26,17 @@ scripts :
 <div class="builds">
 	<div class="builds-download">
 		<h3>Download</h3>
-		<a class="builds-button builds-button-source" href="/downloads/moment.js">
+		<a class="builds-button builds-button-source" href="/downloads/moment.js" download>
 			moment.js
 		</a>
-		<a class="builds-button builds-button-gzipped" href="/downloads/moment.min.js">
+		<a class="builds-button builds-button-gzipped" href="/downloads/moment.min.js" download>
 			moment.min.js
 			<span class="filesize">{{toKb size.moment_min.gzip }}</span>
 		</a>
-		<a class="builds-button builds-button-source" href="/downloads/moment-with-locales.js">
+		<a class="builds-button builds-button-source" href="/downloads/moment-with-locales.js" download>
 			moment-with-locales.js
 		</a>
-		<a class="builds-button builds-button-gzipped" href="/downloads/moment-with-locales.min.js">
+		<a class="builds-button builds-button-gzipped" href="/downloads/moment-with-locales.min.js" download>
 			moment-with-locales.min.js
 			<span class="filesize">{{toKb size.moment_with_locales_min.gzip }}</span>
 		</a>


### PR DESCRIPTION
This adds the [download attribute](https://developers.google.com/web/updates/2011/08/Downloading-resources-in-HTML5-a-download) to the Moment download links, so the JS file will be downloaded rather than just opened in the browser. In my opinion this is preferred and expected behaviour when downloading a file of this kind.