### PR TITLE
Updating moment.tz.guess() docs to indicate using the Internationalization API

### DIFF
--- a/docs/moment-timezone/01-using-timezones/06-guessing-user-timezone.md
+++ b/docs/moment-timezone/01-using-timezones/06-guessing-user-timezone.md
@@ -5,9 +5,9 @@ signature: |
 ---
 
 
-Browser time zone detection is rather tricky to get right, as there is little information provided by the browser.
+Moment Timezone uses the Internationalization API (`Intl.DateTimeFormat().resolvedOptions().timeZone`) in [supported browsers](http://caniuse.com/#feat=internationalization) to determine the user's time zone.
 
-Moment Timezone uses `Date#getTimezoneOffset` and `Date#toString` on a handful of moments around the current year to gather as much information about the browser environment as possible. It then compares that information with all the time zone data loaded and returns the closest match. In case of ties, the time zone with the city with largest population is returned.
+On other browsers, time zone detection is rather tricky to get right, as there is little information provided by those browsers. For those, it will use `Date#getTimezoneOffset` and `Date#toString` on a handful of moments around the current year to gather as much information about the browser environment as possible. It then compares that information with all the time zone data loaded and returns the closest match. In case of ties, the time zone with the city with largest population is returned.
 
 ```js
 moment.tz.guess(); // America/Chicago


### PR DESCRIPTION
(From https://github.com/moment/moment-timezone/issues/421)

The docs for [guess()](http://momentjs.com/timezone/docs/#/using-timezones/guessing-user-timezone/) mention _guessing_ based on `Date#getTimezoneOffset` and `Date#toString` however don't mention (but should) that it actually will use the International API `Intl.DateTimeFormat().resolvedOptions().timeZone`) where supported.