### PR TITLE
Correct fromNow/toNow thresholds

### DIFF
--- a/docs/moment/04-displaying/02-fromnow.md
+++ b/docs/moment/04-displaying/02-fromnow.md
@@ -34,32 +34,32 @@ The breakdown of which string is displayed for each length of time is outlined i
   </thead>
   <tbody>
     <tr>
-      <td>0 to 45 seconds</td>
+      <td>0 to 44 seconds</td>
       <td>s</td>
       <td>a few seconds ago</td>
     </tr>
     <tr>
-      <td>45 to 90 seconds</td>
+      <td>45 to 89 seconds</td>
       <td>m</td>
       <td>a minute ago</td>
     </tr>
     <tr>
-      <td>90 seconds to 45 minutes</td>
+      <td>90 seconds to 44 minutes</td>
       <td>mm</td>
-      <td>2 minutes ago ... 45 minutes ago</td>
+      <td>2 minutes ago ... 44 minutes ago</td>
     </tr>
     <tr>
-      <td>45 to 90 minutes</td>
+      <td>45 to 89 minutes</td>
       <td>h</td>
       <td>an hour ago</td>
     </tr>
     <tr>
-      <td>90 minutes to 22 hours </td>
+      <td>90 minutes to 21 hours </td>
       <td>hh</td>
-      <td>2 hours ago ... 22 hours ago</td>
+      <td>2 hours ago ... 21 hours ago</td>
     </tr>
     <tr>
-      <td>22 to 36 hours</td>
+      <td>22 to 35 hours</td>
       <td>d</td>
       <td>a day ago</td>
     </tr>
@@ -69,22 +69,22 @@ The breakdown of which string is displayed for each length of time is outlined i
       <td>2 days ago ... 25 days ago</td>
     </tr>
     <tr>
-      <td>25 to 45 days</td>
+      <td>26 to 45 days</td>
       <td>M</td>
       <td>a month ago</td>
     </tr>
     <tr>
-      <td>45 to 345 days</td>
+      <td>45 to 319 days</td>
       <td>MM</td>
-      <td>2 months ago ... 11 months ago</td>
+      <td>2 months ago ... 10 months ago</td>
     </tr>
     <tr>
-      <td>345 to 545 days (1.5 years)</td>
+      <td>320 to 547 days (1.5 years)</td>
       <td>y</td>
       <td>a year ago</td>
     </tr>
     <tr>
-      <td>546 days+</td>
+      <td>548 days+</td>
       <td>yy</td>
       <td>2 years ago ... 20 years ago</td>
     </tr>

--- a/docs/moment/04-displaying/04-tonow.md
+++ b/docs/moment/04-displaying/04-tonow.md
@@ -41,32 +41,32 @@ The breakdown of which string is displayed for each length of time is outlined i
   </thead>
   <tbody>
     <tr>
-      <td>0 to 45 seconds</td>
+      <td>0 to 44 seconds</td>
       <td>s</td>
       <td>in seconds</td>
     </tr>
     <tr>
-      <td>45 to 90 seconds</td>
+      <td>45 to 89 seconds</td>
       <td>m</td>
       <td>in a minute</td>
     </tr>
     <tr>
-      <td>90 seconds to 45 minutes</td>
+      <td>90 seconds to 44 minutes</td>
       <td>mm</td>
-      <td>in 2 minutes ... in 45 minutes</td>
+      <td>in 2 minutes ... in 44 minutes</td>
     </tr>
     <tr>
-      <td>45 to 90 minutes</td>
+      <td>45 to 89 minutes</td>
       <td>h</td>
       <td>in an hour</td>
     </tr>
     <tr>
-      <td>90 minutes to 22 hours </td>
+      <td>90 minutes to 21 hours </td>
       <td>hh</td>
-      <td>in 2 hours ... in 22 hours</td>
+      <td>in 2 hours ... in 21 hours</td>
     </tr>
     <tr>
-      <td>22 to 36 hours</td>
+      <td>22 to 35 hours</td>
       <td>d</td>
       <td>in a day</td>
     </tr>
@@ -76,17 +76,17 @@ The breakdown of which string is displayed for each length of time is outlined i
       <td>in 2 days ... in 25 days</td>
     </tr>
     <tr>
-      <td>25 to 45 days</td>
+      <td>26 to 45 days</td>
       <td>M</td>
       <td>in a month</td>
     </tr>
     <tr>
-      <td>45 to 345 days</td>
+      <td>45 to 319 days</td>
       <td>MM</td>
-      <td>in 2 months ... in 11 months</td>
+      <td>in 2 months ... in 10 months</td>
     </tr>
     <tr>
-      <td>345 to 547 days (1.5 years)</td>
+      <td>320 to 547 days (1.5 years)</td>
       <td>y</td>
       <td>in a year</td>
     </tr>


### PR DESCRIPTION
The charts showing the to/from thresholds were not reflecting the functionality that has existed since 2014 from moment/moment@af40f1dc864279850f503d4cee24c846f4b9d21b.  Updating the docs.