### PR TITLE
Use https and update GA code

### DIFF
--- a/pages/layout/base.hbs
+++ b/pages/layout/base.hbs
@@ -3,11 +3,17 @@
 	<head>
 		<meta charset="utf-8" />
 
-		<link href='http://fonts.googleapis.com/css?family=Montserrat:400,700' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Montserrat:400,700' rel='stylesheet' type='text/css'>
 		<link rel="stylesheet" href="/static/css/style.css" />
 		<link rel="shortcut icon" href="/static/img/{{repo}}-favicon.png" />
 
 		<title>{{#if isMoment}}Moment.js{{else}}Moment Timezone{{/if}} | {{title}}</title>
+		<script>
+			window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+			ga('create', 'UA-10641787-5', 'auto');
+			ga('send', 'pageview');
+		</script>
+		<script async src='https://www.google-analytics.com/analytics.js'></script>
 	</head>
 
 	<body class="is-{{repo}}">
@@ -49,15 +55,5 @@
 		{{#each scripts}}
 			<script src="/static/js/{{this}}.js"></script>
 		{{/each}}
-
-		<script>
-			window._gaq = [['_setAccount','UA-10641787-5'],['_trackPageview'],['_trackPageLoadTime']];
-			(function(d, c) {
-				var ga = d.createElement(c); ga.async = true;
-				ga.src = "http://www.google-analytics.com/ga.js";
-				var s = d.getElementsByTagName(c)[0];
-				s.parentNode.insertBefore(ga, s);
-			})(document, 'script');
-		</script>
 	</body>
 </html>


### PR DESCRIPTION
This changes the font to be loaded from https.
Also updates the GA code snippet to the latest version and
moved the snippet to the end of `<head>` as recommended
by google. (https://developers.google.com/analytics/devguides/collection/analyticsjs/)

`_trackPageLoadTime` is enabled by default now.

I noticed that both scripts were loading over http, which resulted in them being blocked in chrome if visiting https://momentjs.com