### PR TITLE
Add moment-business to plugins

### DIFF
--- a/docs/moment/10-plugins/19-moment-business.md
+++ b/docs/moment/10-plugins/19-moment-business.md
@@ -1,0 +1,22 @@
+---
+title: Business
+signature: |
+  npm install moment-business
+---
+
+This is a Moment.js library that allows Moment operations for Western work weeks: 7 day weeks where Saturday and Sunday
+are non-work days.
+
+For example,
+
+```js
+import business from 'moment-business';
+
+// true if the moment is Mon-Fri, false otherwise
+business.isWeekDay(someMoment);
+
+// Adds five work days to the Moment
+business.addWeekDays(someMoment, 5);
+```
+
+The repository is located at [github.com/jmeas/moment-business](https://github.com/jmeas/moment-business)


### PR DESCRIPTION
Note that this isn't a "plugin" per se, as I refactored that API away so that the moment obj is no longer modified. So feel free to close this if this lib doesn't qualify for that reason :)

However, now I'm thinking that I'll add a `business.install()` method that would make it a plugin...

Well, anyway, let me know what you think.