### PR TITLE
update script concat recommendation for HTTP/2

### DIFF
--- a/docs/moment/00-use-it/02-browser.md
+++ b/docs/moment/00-use-it/02-browser.md
@@ -10,4 +10,4 @@ title: Browser
 </script>
 ```
 
-Moment.js is available on [cdnjs.com](https://cdnjs.com/libraries/moment.js). Remember though, cool kids concatenate their scripts to minimize http requests.
+Moment.js is available on [cdnjs.com](https://cdnjs.com/libraries/moment.js). Remember though, unless you are using HTTP/2 then script concatenation into bundles is better as it minimizies HTTP requests.

--- a/docs/moment/00-use-it/02-browser.md
+++ b/docs/moment/00-use-it/02-browser.md
@@ -10,4 +10,4 @@ title: Browser
 </script>
 ```
 
-Moment.js is available on [cdnjs.com](https://cdnjs.com/libraries/moment.js). Remember though, unless you are using HTTP/2 then script concatenation into bundles is better as it minimizies HTTP requests.
+Moment.js is available on [cdnjs.com](https://cdnjs.com/libraries/moment.js). Remember though, unless you are using HTTP/2 then script concatenation into bundles is better as it minimizies the costs of HTTP/1 requests.


### PR DESCRIPTION
- In HTTP/1 multiple requests are slow as they block on the TCP level, as such, in HTTP/1 concatenation is better, as it eliminates the performance benefit of having a single request eliminating the blocking risk
- In HTTP/2 multiple requests occur in parallel on the TCP level, as such eliminating the need of the HTTP/1 concatenation practice while offering similar performance
- Using multiple requests increases the likelihood of a request being bundled, especially if the resource is popular, especially in the cases of CDN usage - whereas concatenation eliminates this benefit, as parts of the bundle cannot be cached as only the whole bundle can be
- As HTTP/2 multiple requests offers the same benefits of HTTP/1 single requests (concatenation) but as multiple requests increases chances of caching, then using multiple requests with HTTP/2 offers better performance over HTTP/1 concatenation practices