### PR TITLE
Consistent typography of "Note:"

### DIFF
--- a/docs/moment/01-parsing/01-now.md
+++ b/docs/moment/01-parsing/01-now.md
@@ -17,6 +17,6 @@ var now = moment();
 
 This is essentially the same as calling `moment(new Date())`.
 
-**Note**: From version **2.14.0**, `moment([])` and `moment({})` also return
+**Note:** From version **2.14.0**, `moment([])` and `moment({})` also return
 now. They used to default to start-of-today before 2.14.0, but that was
 arbitrary so it was changed.

--- a/docs/moment/01-parsing/02-string.md
+++ b/docs/moment/01-parsing/02-string.md
@@ -14,7 +14,7 @@ var day = moment("1995-12-25");
 **Warning:** Browser support for parsing strings [is inconsistent](http://dygraphs.com/date-formats.html). Because there is no specification on which formats should be supported, what works in some browsers will not work in other browsers.
 
 <!--
-**Note**: This has been the source of a lot of confusion, because moments created via `Date` constructor don't support `isValid` and also work unreliably. So it would be soon deprecated. From version 2.6.0 there is a way to prevent Date constructor usage - just set `moment.createFromInputFallback` to an empty function.
+**Note:** This has been the source of a lot of confusion, because moments created via `Date` constructor don't support `isValid` and also work unreliably. So it would be soon deprecated. From version 2.6.0 there is a way to prevent Date constructor usage - just set `moment.createFromInputFallback` to an empty function.
 -->
 
 For consistent results parsing anything other than ISO 8601 strings, you should use [String + Format](#/parsing/string-format/).

--- a/docs/moment/01-parsing/14-parse-zone.md
+++ b/docs/moment/01-parsing/14-parse-zone.md
@@ -19,4 +19,4 @@ var s = "2013-01-01T00:00:00-13:00";
 moment(s).utcOffset(s);
 ```
 
-**Note**: this method only works for a single string argument, not a string and format.
+**Note:** this method only works for a single string argument, not a string and format.

--- a/docs/moment/02-get-set/00-intro.md
+++ b/docs/moment/02-get-set/00-intro.md
@@ -23,4 +23,4 @@ moment.utc().seconds()   === new Date().getUTCSeconds();
 
 For convenience, both singular and plural method names exist as of version **2.0.0**.
 
-**Note**: All of these methods mutate the original moment when used as setters.
+**Note:** All of these methods mutate the original moment when used as setters.

--- a/docs/moment/02-get-set/12-month.md
+++ b/docs/moment/02-get-set/12-month.md
@@ -13,7 +13,7 @@ Gets or sets the month.
 
 Accepts numbers from 0 to 11. If the range is exceeded, it will bubble up to the year.
 
-**Note**: Months are zero indexed, so January is month 0.
+**Note:** Months are zero indexed, so January is month 0.
 
 As of **2.1.0**, a month name is also supported. This is parsed in the moment's current locale.
 

--- a/docs/moment/03-manipulating/05-max.md
+++ b/docs/moment/03-manipulating/05-max.md
@@ -5,7 +5,7 @@ signature: |
   moment().max(Moment|String|Number|Date|Array);
 ---
 
-**NOTE**: This function has been **deprecated** in **2.7.0**. Consider [`moment.min`](/docs/#/get-set/min/) instead.
+**Note:** This function has been **deprecated** in **2.7.0**. Consider [`moment.min`](/docs/#/get-set/min/) instead.
 
 ------
 

--- a/docs/moment/03-manipulating/06-min.md
+++ b/docs/moment/03-manipulating/06-min.md
@@ -5,7 +5,7 @@ signature: |
   moment().min(Moment|String|Number|Date|Array);
 ---
 
-**NOTE**: This function has been **deprecated** in **2.7.0**. Consider [`moment.max`](/docs/#/get-set/max/) instead.
+**Note:** This function has been **deprecated** in **2.7.0**. Consider [`moment.max`](/docs/#/get-set/max/) instead.
 
 ------
 

--- a/docs/moment/03-manipulating/09-utc-offset.md
+++ b/docs/moment/03-manipulating/09-utc-offset.md
@@ -9,7 +9,7 @@ signature: |
 
 Get the UTC offset in minutes.
 
-**NOTE**: Unlike [`moment.fn.zone`](/docs/#/manipulating/timezone-offset/) this
+**Note:** Unlike [`moment.fn.zone`](/docs/#/manipulating/timezone-offset/) this
 function returns the real offset from UTC, not the reverse offset (as returned
 by `Date.prototype.getTimezoneOffset`).
 

--- a/docs/moment/03-manipulating/10-timezone-offset.md
+++ b/docs/moment/03-manipulating/10-timezone-offset.md
@@ -6,7 +6,7 @@ signature: |
   moment().zone(Number|String);
 ---
 
-**NOTE**: This function has been **deprecated** in **2.9.0**. Consider [`moment.fn.utcOffset`](/docs/#/manipulating/utc-offset/) instead.
+**Note:** This function has been **deprecated** in **2.9.0**. Consider [`moment.fn.utcOffset`](/docs/#/manipulating/utc-offset/) instead.
 
 Get the time zone offset in minutes.
 

--- a/docs/moment/04-displaying/06-calendar-time.md
+++ b/docs/moment/04-displaying/06-calendar-time.md
@@ -56,7 +56,7 @@ moment().calendar(null, {
 ```
 `sameElse` is used as the format when the moment is more than a week away from the `referenceTime`
 
-**Note**: From version **2.14.0** the formats argument to calendar can be
+**Note:** From version **2.14.0** the formats argument to calendar can be
 a callback that is executed within the moment context with a single argument
 now:
 

--- a/docs/moment/04-displaying/17-inspect.md
+++ b/docs/moment/04-displaying/17-inspect.md
@@ -17,5 +17,5 @@ moment(new Date('nope')).inspect() // 'moment.invalid(/* Invalid Date */)'
 moment('blah', 'YYYY').inspect() // 'moment.invalid(/* blah */)'
 ```
 
-**NOTE:** This function is mostly intended for debugging, not all cases are
+**Note:** This function is mostly intended for debugging, not all cases are
 handled precisely.

--- a/docs/moment/05-query/08-is-dst-shifted.md
+++ b/docs/moment/05-query/08-is-dst-shifted.md
@@ -5,7 +5,7 @@ signature: |
   moment('2013-03-10 2:30', 'YYYY-MM-DD HH:mm').isDSTShifted()
 ---
 
-**Note**: As of version **2.14.0** this function is **deprecated**. It doesn't give
+**Note:** As of version **2.14.0** this function is **deprecated**. It doesn't give
 the right answer after modifying the moment object. For more information refert
 to [moment/3160](https://github.com/moment/moment/pull/3160)
 

--- a/docs/moment/07-customization/02-month-abbreviations.md
+++ b/docs/moment/07-customization/02-month-abbreviations.md
@@ -65,7 +65,7 @@ moment.updateLocale('en', {
 });
 ```
 
-**Note**: From version **2.11.0**, like `Locale#months`, `Locale#monthsShort` can be an object with `standalone` and `format` cases.
+**Note:** From version **2.11.0**, like `Locale#months`, `Locale#monthsShort` can be an object with `standalone` and `format` cases.
 
 ```javascript
 moment.updateLocale('en', {

--- a/docs/moment/07-customization/03-weekday-names.md
+++ b/docs/moment/07-customization/03-weekday-names.md
@@ -63,7 +63,7 @@ moment.updateLocale('en', {
 });
 ```
 
-**Note**: From version **2.11.0** format/standalone cases can be passed as well. `isFormat` will be used against the full format string to determine which form to use.
+**Note:** From version **2.11.0** format/standalone cases can be passed as well. `isFormat` will be used against the full format string to determine which form to use.
 
 ```javascript
 moment.updateLocale('en', {

--- a/docs/moment/07-customization/13-relative-time-threshold.md
+++ b/docs/moment/07-customization/13-relative-time-threshold.md
@@ -59,4 +59,4 @@ signature: |
   moment.relativeTimeThreshold('M', 10);
 ```
 
-**NOTE**: Retrieving thresholds was added in **2.8.1**.
+**Note:** Retrieving thresholds was added in **2.8.1**.


### PR DESCRIPTION
Lower case + colon in **bold**.