### PR TITLE
Update 11-as-javascript-date.md

### DIFF
--- a/docs/moment/04-displaying/11-as-javascript-date.md
+++ b/docs/moment/04-displaying/11-as-javascript-date.md
@@ -6,8 +6,8 @@ signature: |
 ---
 
 
-To get the native Date object that Moment.js wraps, use `moment#toDate`.
+To get a copy of the native Date object that Moment.js wraps, use `moment#toDate`.
 
-This will return the `Date` that the moment uses, so any changes to that `Date` will cause the moment to change. If you want a `Date` that is a copy, use `moment#clone` before you use `moment#toDate`.
+This will return a copy of the `Date` that the moment uses, so any changes to that `Date` will not cause moment to change. If you want to change the moment `Date`, see `moment#manipulate` or `moment#set`.
 
 `moment#native` has been replaced by `moment#toDate` and has been deprecated as of **1.6.0**.


### PR DESCRIPTION
Update documentation to reflect current toDate behavior which returns a copy of native Date

This pull request references https://github.com/moment/moment/issues/3822