### PR TITLE
Fix typo in duration adding docs

### DIFF
--- a/docs/moment/08-durations/11-add.md
+++ b/docs/moment/08-durations/11-add.md
@@ -20,5 +20,5 @@ var b = moment.duration(2, 'd');
 a.add(b).days(); // 3
 ```
 
-Note that adding an ivalid duration to any other duration results in an invalid
+Note that adding an invalid duration to any other duration results in an invalid
 duration.


### PR DESCRIPTION
'ivalid' should be 'invalid'.