### PR TITLE
Issue #327

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ node_modules
 .DS_Store
 .sass-cache
 
+# Idea
+.idea
+
 # Sublime
 *.sublime-project
 *.sublime-workspace

--- a/docs/moment/01-parsing/14-parse-zone.md
+++ b/docs/moment/01-parsing/14-parse-zone.md
@@ -14,7 +14,6 @@ signature: |
 Moment normally interprets input times as local times (or UTC times if `moment.utc()` is used). However, often the input string itself contains time zone information. `#parseZone` parses the time and then sets the zone according to the input string.
 
 ```javascript
-moment('2013-01-01T13:00-1300').parseZone().utcOffset(); //-780 ("-13:00" in total minutes)
 moment.parseZone("2013-01-01T00:00:00-13:00").utcOffset(); // -780 ("-13:00" in total minutes)
 moment.parseZone('2013 01 01 05 -13:00', 'YYYY MM DD HH ZZ').utcOffset(); // -780  ("-13:00" in total minutes)
 moment.parseZone('2013-01-01-13:00', ['DD MM YYYY ZZ', 'YYYY MM DD ZZ']).utcOffset(); // -780  ("-13:00" in total minutes);

--- a/docs/moment/01-parsing/14-parse-zone.md
+++ b/docs/moment/01-parsing/14-parse-zone.md
@@ -2,14 +2,31 @@
 title: parseZone
 version: 2.3.0
 signature: |
+  moment.parseZone()
   moment.parseZone(String)
+  moment.parseZone(String, String)
+  moment.parseZone(String, [String])
+  moment.parseZone(String, String, Boolean)
+  moment.parseZone(String, String, String, Boolean)
 ---
 
 
 Moment normally interprets input times as local times (or UTC times if `moment.utc()` is used). However, often the input string itself contains time zone information. `#parseZone` parses the time and then sets the zone according to the input string.
 
 ```javascript
-moment.parseZone("2013-01-01T00:00:00-13:00").utcOffset(); // -780  ("-13:00" in total minutes)
+moment('2013-01-01T13:00-1300').parseZone().utcOffset(); //-780 ("-13:00" in total minutes)
+moment.parseZone("2013-01-01T00:00:00-13:00").utcOffset(); // -780 ("-13:00" in total minutes)
+moment.parseZone('2013 01 01 05 -13:00', 'YYYY MM DD HH ZZ').utcOffset(); // -780  ("-13:00" in total minutes)
+moment.parseZone('2013-01-01-13:00', ['DD MM YYYY ZZ', 'YYYY MM DD ZZ']).utcOffset(); // -780  ("-13:00" in total minutes);
+```
+
+It also allows you to pass locale and strictness arguments.
+
+```javascript
+moment.parseZone("2013 01 01 -13:00", 'YYYY MM DD ZZ', true).utcOffset(); // -780  ("-13:00" in total minutes)
+moment.parseZone("2013-01-01-13:00", 'YYYY MM DD ZZ', true).utcOffset(); // NaN (doesn't pass the strictness check)
+moment.parseZone("2013 01 01 -13:00", 'YYYY MM DD ZZ', 'fr', true).utcOffset(); // -780 (with locale and strictness argument)
+moment.parseZone("2013 01 01 -13:00", ['DD MM YYYY ZZ', 'YYYY MM DD ZZ'], 'fr', true).utcOffset(); // -780 (with locale and strictness argument alongside an array of formats)
 ```
 
 `moment.parseZone` is equivalent to parsing the string and using `moment#utcOffset` to parse the zone.
@@ -18,5 +35,3 @@ moment.parseZone("2013-01-01T00:00:00-13:00").utcOffset(); // -780  ("-13:00" in
 var s = "2013-01-01T00:00:00-13:00";
 moment(s).utcOffset(s);
 ```
-
-**Note:** this method only works for a single string argument, not a string and format.


### PR DESCRIPTION
Modified the parseZone method description for when arguments for formats, locale and strictness can be passed in (plus where all arguments can be omitted).

Left off this piece of code:
`moment('2013-01-01T15:00+0200').parseZone().format("ZZ")`
 since it looks like this is an example of getting the formatted the UTC offset (I used `utcOffset()` rather than `format()`).
