### PR TITLE
improve the parseZone() description

### DIFF
--- a/docs/moment/01-parsing/14-parse-zone.md
+++ b/docs/moment/01-parsing/14-parse-zone.md
@@ -10,8 +10,7 @@ signature: |
   moment.parseZone(String, String, String, Boolean)
 ---
 
-
-Moment normally interprets input times as local times (or UTC times if `moment.utc()` is used). However, often the input string itself contains time zone information. `#parseZone` parses the time and then sets the zone according to the input string.
+Moment's string parsing functions like `moment(string)` and `moment.utc(string)` accept offset information if provided, but convert the resulting Moment object to local or UTC time. In contrast, `moment.parseZone()` parses the string but keeps the resulting Moment object in a fixed-offset timezone with the provided offset in the string.
 
 ```javascript
 moment.parseZone("2013-01-01T00:00:00-13:00").utcOffset(); // -780 ("-13:00" in total minutes)


### PR DESCRIPTION
I recently reread the `parseZone()` description and was annoyed at how bad it was. Then I looked up who [wrote it](https://github.com/moment/momentjs.com/commit/b2c7bace27acf6098fe42f4d37f731f060567565) and got embarrassed. So here is the fix!