### PR TITLE
Update Customization > Relative time documentation

### DIFF
--- a/docs/moment/07-customization/07-relative-time.md
+++ b/docs/moment/07-customization/07-relative-time.md
@@ -25,7 +25,8 @@ moment.updateLocale('en', {
     relativeTime : {
         future: "in %s",
         past:   "%s ago",
-        s:  "seconds",
+        s  : 'a few seconds',
+        ss : '%d seconds',
         m:  "a minute",
         mm: "%d minutes",
         h:  "an hour",


### PR DESCRIPTION
Commit [9a7ada4](https://github.com/moment/moment/commit/9a7ada487f5aa50ab8244a6a1f0ec560e5922b1b) changed proto.relativeTime. The documentation does not reflect it yet.

Ref: https://github.com/moment/moment/commit/9a7ada487f5aa50ab8244a6a1f0ec560e5922b1b#diff-0ebac9fd7729c336cf0b0e1cb42b3fca