### PR TITLE
TypeScript docs: Clarified remark about allowSyntheticDefaultImports

### DIFF
--- a/docs/moment/00-use-it/08-typescript.md
+++ b/docs/moment/00-use-it/08-typescript.md
@@ -19,7 +19,7 @@ import * as moment from 'moment';
 let now = moment().format('LLLL');
 ```
 
-**Note:** If you have trouble importing moment, try add ```"allowSyntheticDefaultImports": true``` in ```compilerOptions``` in your ```tsconfig.json``` file and then using the syntax
+**Note:** If you have trouble importing moment, try adding ```"allowSyntheticDefaultImports": true``` in ```compilerOptions``` in your ```tsconfig.json``` file and then using the syntax
 <!-- skip-example -->
 ```javascript
 import moment from 'moment';

--- a/docs/moment/00-use-it/08-typescript.md
+++ b/docs/moment/00-use-it/08-typescript.md
@@ -19,7 +19,11 @@ import * as moment from 'moment';
 let now = moment().format('LLLL');
 ```
 
-**Note:** If you have trouble importing moment, try add ```"allowSyntheticDefaultImports": true``` in ```compilerOptions``` in your ```tsconfig.json``` file.
+**Note:** If you have trouble importing moment, try add ```"allowSyntheticDefaultImports": true``` in ```compilerOptions``` in your ```tsconfig.json``` file and then using the syntax
+<!-- skip-example -->
+```javascript
+import moment from 'moment';
+```
 
 **Locale Import**
 

--- a/docs/moment/00-use-it/08-typescript.md
+++ b/docs/moment/00-use-it/08-typescript.md
@@ -19,7 +19,7 @@ import * as moment from 'moment';
 let now = moment().format('LLLL');
 ```
 
-**Note:** If you have trouble importing moment, try adding ```"allowSyntheticDefaultImports": true``` in ```compilerOptions``` in your ```tsconfig.json``` file and then using the syntax
+**Note:** If you have trouble importing moment, try adding ```"allowSyntheticDefaultImports": true``` in ```compilerOptions``` in your ```tsconfig.json``` file and then use the syntax
 <!-- skip-example -->
 ```javascript
 import moment from 'moment';


### PR DESCRIPTION
Added clarification around the remark about the `allowSyntheticDefaultImports` flag, showing how the import statement should be rewritten.