### PR TITLE
Corrected docs for localized timezone methods

### DIFF
--- a/docs/moment/04-displaying/01-format.md
+++ b/docs/moment/04-displaying/01-format.md
@@ -352,32 +352,32 @@ There are upper and lower case variations on the same formats. The lowercase ver
     <tr>
       <td><b>Month name, day of month, year</b></td>
       <td>LL</td>
-      <td>September 4 1986</td>
+      <td>September 4, 1986</td>
     </tr>
     <tr>
       <td></td>
       <td>ll</td>
-      <td>Sep 4 1986</td>
+      <td>Sep 4, 1986</td>
     </tr>
     <tr>
       <td><b>Month name, day of month, year, time</b></td>
       <td>LLL</td>
-      <td>September 4 1986 8:30 PM</td>
+      <td>September 4, 1986 8:30 PM</td>
     </tr>
     <tr>
       <td></td>
       <td>lll</td>
-      <td>Sep 4 1986 8:30 PM</td>
+      <td>Sep 4, 1986 8:30 PM</td>
     </tr>
     <tr>
       <td><b>Month name, day of month, day of week, year, time</b></td>
       <td>LLLL</td>
-      <td>Thursday, September 4 1986 8:30 PM</td>
+      <td>Thursday, September 4, 1986 8:30 PM</td>
     </tr>
     <tr>
       <td></td>
       <td>llll</td>
-      <td>Thu, Sep 4 1986 8:30 PM</td>
+      <td>Thu, Sep 4, 1986 8:30 PM</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
`,` was missing throughout the localized timezone docs.

```
> const moment = require('moment');
undefined
> moment(new Date()).format('ll');
'Sep 17, 2017'
> moment(new Date()).format('LL');
'September 17, 2017'
> moment(new Date()).format('lll');
'Sep 17, 2017 2:43 PM'
> moment(new Date()).format('LLL');
'September 17, 2017 2:43 PM'
> moment(new Date()).format('llll');
'Sun, Sep 17, 2017 2:43 PM'
> moment(new Date()).format('LLLL');
'Sunday, September 17, 2017 2:44 PM'
````