### PR TITLE
moment().seconds(30) returns an object

### DIFF
--- a/docs/moment/01-parsing/13-utc.md
+++ b/docs/moment/01-parsing/13-utc.md
@@ -32,7 +32,7 @@ moment.utc().format(); // 2013-02-04T18:35:24+00:00
 Additionally, while in UTC mode, all getters and setters will internally use the `Date#getUTC*` and `Date#setUTC*` methods instead of the `Date#get*` and `Date#set*` methods.
 
 ```javascript
-moment.utc().seconds(30) === new Date().setUTCSeconds(30);
+moment.utc().seconds(30).valueOf() === new Date().setUTCSeconds(30);
 moment.utc().seconds()   === new Date().getUTCSeconds();
 ```
 

--- a/docs/moment/02-get-set/00-intro.md
+++ b/docs/moment/02-get-set/00-intro.md
@@ -10,14 +10,14 @@ Calling these methods without parameters acts as a getter, and calling them with
 These map to the corresponding function on the native `Date` object.
 
 ```javascript
-moment().seconds(30) === new Date().setSeconds(30);
+moment().seconds(30).valueOf() === new Date().setSeconds(30);
 moment().seconds()   === new Date().getSeconds();
 ```
 
 If you are in [UTC mode](#/manipulating/utc/), they will map to the UTC equivalent.
 
 ```javascript
-moment.utc().seconds(30) === new Date().setUTCSeconds(30);
+moment.utc().seconds(30).valueOf() === new Date().setUTCSeconds(30);
 moment.utc().seconds()   === new Date().getUTCSeconds();
 ```
 


### PR DESCRIPTION
I have created this issue since there is a mistake in the documentation that I had found, here is the link for complete description of the issue. 
https://github.com/moment/momentjs.com/issues/447#issuecomment-335741178

Please accept this PR since it is bit confusing for anyone who follows this documentation on momentjs.com