### PR TITLE
Deprecation warnings and method signatures

### DIFF
--- a/docs/moment/02-get-set/05-date.md
+++ b/docs/moment/02-get-set/05-date.md
@@ -20,3 +20,5 @@ Accepts numbers from 1 to 31. If the range is exceeded, it will bubble up to the
 Bad: `moment().date(day).month(month).year(year)`
 
 Good: `moment().year(year).month(month).date(day)`
+
+**2.16.0** deprecated using ``moment().dates()``. Use ``moment().date()`` instead.

--- a/docs/moment/02-get-set/12-month.md
+++ b/docs/moment/02-get-set/12-month.md
@@ -32,3 +32,5 @@ moment([2012, 0, 31]).month(1).format("YYYY-MM-DD"); // 2012-03-02
 // after 2.1.0
 moment([2012, 0, 31]).month(1).format("YYYY-MM-DD"); // 2012-02-29
 ```
+
+**2.16.0** deprecated using ``moment().months()``. Use ``moment().month()`` instead.

--- a/docs/moment/02-get-set/13-quarter.md
+++ b/docs/moment/02-get-set/13-quarter.md
@@ -4,6 +4,8 @@ version: 2.6.0
 signature: |
   moment().quarter(); // Number
   moment().quarter(Number);
+  moment().quarters(); // Number
+  moment().quarters(Number);
 ---
 
 

--- a/docs/moment/02-get-set/14-year.md
+++ b/docs/moment/02-get-set/14-year.md
@@ -12,3 +12,5 @@ signature: |
 Gets or sets the year.
 
 Accepts numbers from -270,000 to 270,000.
+
+**2.16.0** deprecated using ``moment().years()``. Use ``moment().year()`` instead.

--- a/docs/moment/06-i18n/02-instance-locale.md
+++ b/docs/moment/06-i18n/02-instance-locale.md
@@ -3,10 +3,10 @@ title: Changing locales locally
 version: 1.7.0
 signature: |
   // From version 2.8.1 onward
-  moment().locale(String);
+  moment().locale(String|Boolean);
 
   // Deprecated version 2.8.1
-  moment().lang(String);
+  moment().lang(String|Boolean);
 ---
 
 


### PR DESCRIPTION
1. Added `quarters` method to the doc. 
2. Added deprecation warnings for the `years`, `months` and `dates` accessors.
3. Updated moment().locale() method signature