### PR TITLE
Fix `yarn` installation method

### DIFF
--- a/pages/moment-timezone/index.hbs
+++ b/pages/moment-timezone/index.hbs
@@ -49,7 +49,7 @@ scripts :
 		<h3>Install</h3>
 		<pre><code>bower install moment-timezone --save <span class="comment"># bower</span>
 npm install moment-timezone --save   <span class="comment"># npm</span>
-yarn add moment                      <span class="comment"># Yarn</span>
+yarn add moment-timezone             <span class="comment"># Yarn</span>
 Install-Package Moment.Timezone.js   <span class="comment"># NuGet</span></code></pre>
 	</div>
 </div>


### PR DESCRIPTION
The yarn installation method only installed `moment` and not `moment-timezone`.