### PR TITLE
Updates docs related to toISOString()

### DIFF
--- a/docs/moment/04-displaying/14-as-iso-string.md
+++ b/docs/moment/04-displaying/14-as-iso-string.md
@@ -11,7 +11,7 @@ Formats a string to the ISO8601 standard.
 moment().toISOString() // 2013-02-04T22:44:30.652Z
 ```
 
-Note that ``.toISOString()`` always returns a timestamp in UTC, even if the moment in question is in local mode. It also includes milliseconds unlike  moment.format(),which doesn't.
+Note that ``.toISOString()`` always returns a timestamp in UTC, even if the moment in question is in local mode. It also includes milliseconds unlike  moment.format(), which doesn't.
 This is done to provide consistency with the specification for native JavaScript Date ``.toISOString()``, as outlined in 
 [ the ES2015 specification](https://www.ecma-international.org/ecma-262/6.0/#sec-date.prototype.toisostring).
 

--- a/docs/moment/04-displaying/14-as-iso-string.md
+++ b/docs/moment/04-displaying/14-as-iso-string.md
@@ -11,7 +11,7 @@ Formats a string to the ISO8601 standard.
 moment().toISOString() // 2013-02-04T22:44:30.652Z
 ```
 
-Note that ``.toISOString()`` always returns a timestamp in UTC, even if the moment in question is in local mode.
+Note that ``.toISOString()`` always returns a timestamp in UTC, even if the moment in question is in local mode. It also includes milliseconds unlike  moment.format(),which doesn't.
 This is done to provide consistency with the specification for native JavaScript Date ``.toISOString()``, as outlined in 
 [ the ES2015 specification](https://www.ecma-international.org/ecma-262/6.0/#sec-date.prototype.toisostring).
 


### PR DESCRIPTION
Added that it also returns milliseconds. Probably a fix for this  [issue](https://github.com/moment/moment/issues/2821).