### PR TITLE
Update zone offset example

### DIFF
--- a/docs/moment-timezone/02-zone-object/03-offset.md
+++ b/docs/moment-timezone/02-zone-object/03-offset.md
@@ -1,14 +1,14 @@
 ---
 title: Offset
 signature: |
-  zone.offset(timestamp); // 480
+  zone.utcOffset(timestamp); // 480
 ---
 
 Get the offset for a given timestamp from a `Zone`.
 
 ```js
-moment.tz.zone('America/Los_Angeles').offset(1403465838805); // 420
-moment.tz.zone('America/Los_Angeles').offset(1388563200000); // 480
+moment.tz.zone('America/Los_Angeles').utcOffset(1403465838805); // 420
+moment.tz.zone('America/Los_Angeles').utcOffset(1388563200000); // 480
 ```
 
 POSIX compatibility requires that the offsets are inverted. Therefore, Etc/GMT-X will have an offset of `+X` and Etc/GMT+X will have an offset of `-X`. This is a result of IANA's [Time Zone Database](https://github.com/eggert/tz/blob/2017b/etcetera#L36-L42) and not an arbitrary choice by Moment.js. Thus, using locality based identifiers is preferred over fixed-offset identifiers.


### PR DESCRIPTION
`zone.offset` has been deprecated in favor of `zone.utcOffset`, see #398