### PR TITLE
remove references from versions lower than 2.0

### DIFF
--- a/docs/moment/01-parsing/02-string.md
+++ b/docs/moment/01-parsing/02-string.md
@@ -69,7 +69,7 @@ If a time part is included, an offset from UTC can also be included as `+-HH:mm`
 2013-02-08 09:30:26.123+07     # +-HH
 ```
 
-**Note:** Automatic cross browser ISO-8601 support was added in version **1.5.0**. Support for the week and ordinal formats was added in version **2.3.0**.
+**Note:** Support for the week and ordinal formats was added in version **2.3.0**.
 
 If a string does not match any of the above formats and is not able to be parsed with `Date.parse`, `moment#isValid` will return false.
 

--- a/docs/moment/04-displaying/01-format.md
+++ b/docs/moment/04-displaying/01-format.md
@@ -277,8 +277,6 @@ moment('gibberish').format('YYYY MM DD');         // "Invalid date"
       <td>
         EST CST ... MST PST
         <br/>
-        <b>Note:</b> as of <b>1.6.0</b>, the z/zz format tokens have been deprecated from plain moment objects. <a href="https://github.com/moment/moment/issues/162">Read more about it here.</a>
-        However, they *do* work if you are using a specific time zone with the moment-timezone addon.
       </td>
     </tr>
     <tr>
@@ -306,9 +304,6 @@ moment('gibberish').format('YYYY MM DD');         // "Invalid date"
   </tbody>
 </table>
 
-`Z ZZ` were added in **1.2.0**.
-
-`S SS SSS` were added in **1.6.0**.
 
 `X` was added in **2.0.0**.
 
@@ -382,7 +377,7 @@ There are upper and lower case variations on the same formats. The lowercase ver
   </tbody>
 </table>
 
-`L LL LLL LLLL LT` are available in version **1.3.0**. `l ll lll llll` are available in **2.0.0**.
+`l ll lll llll` are available in **2.0.0**.
 `LTS` was added in **2.8.4**.
 
 #### Escaping characters
@@ -408,8 +403,6 @@ To compare Moment.js formatting speed against other libraries, check out [this c
 If you are more comfortable working with strftime instead of LDML-like parsing tokens, you can use Ben Oakes' plugin. [benjaminoakes/moment-strftime](https://github.com/benjaminoakes/moment-strftime).
 
 #### Default format
-
-As of version **1.5.0**, calling `moment#format` without a format will default to `moment.defaultFormat`. Out of the box, `moment.defaultFormat` is the ISO8601 format `YYYY-MM-DDTHH:mm:ssZ`.
 
 As of version **2.13.0**, when in UTC mode, the default format is governed by `moment.defaultFormatUtc` which is in the format `YYYY-MM-DDTHH:mm:ss[Z]`. This returns ``Z`` as the offset, instead of ``+00:00``. 
 

--- a/docs/moment/04-displaying/11-as-javascript-date.md
+++ b/docs/moment/04-displaying/11-as-javascript-date.md
@@ -9,5 +9,3 @@ signature: |
 To get a copy of the native Date object that Moment.js wraps, use `moment#toDate`.
 
 This will return a copy of the `Date` that the moment uses, so any changes to that `Date` will not cause moment to change. If you want to change the moment `Date`, see `moment#manipulate` or `moment#set`.
-
-`moment#native` has been replaced by `moment#toDate` and has been deprecated as of **1.6.0**.

--- a/docs/moment/06-i18n/02-instance-locale.md
+++ b/docs/moment/06-i18n/02-instance-locale.md
@@ -12,8 +12,6 @@ signature: |
 
 A global locale configuration can be problematic when passing around moments that may need to be formatted into different locale.
 
-In **1.7.0** we added instance specific locale configurations.
-
 ```javascript
 moment.locale('en'); // default the locale to English
 var localLocale = moment();

--- a/docs/moment/07-customization/07-relative-time.md
+++ b/docs/moment/07-customization/07-relative-time.md
@@ -58,5 +58,3 @@ The `key` argument refers to the replacement key in the `Locale#relativeTime ` o
 The `number` argument refers to the number of units for that key. For `m`, the number is the number of minutes, etc.
 
 The `withoutSuffix` argument will be true if the token will be displayed without a suffix, and false if it will be displayed with a suffix. (The reason for the inverted logic is because the default behavior is to display with the suffix.)
-
-The `isFuture` argument will be true if it is going to use the future suffix/prefix and false if it is going to use the past prefix/suffix. The `isFuture` argument was added in version **1.6.0**.

--- a/docs/moment/07-customization/08-am-pm.md
+++ b/docs/moment/07-customization/08-am-pm.md
@@ -40,8 +40,6 @@ moment.updateLocale('zh-cn', {
 });
 ```
 
-Before version **1.6.0**, `Locale#meridiem` was a map of upper and lowercase versions of am/pm.
-
 ```javascript
 moment.updateLocale('en', {
     meridiem : {
@@ -52,5 +50,3 @@ moment.updateLocale('en', {
     }
 });
 ```
-
-This has been deprecated. The **1.6.0** callback function syntax is now used instead.


### PR DESCRIPTION
I've searched from references within the whole application but I just find it on documentation.
I hope this is what you expected as a task to be done.

PS: I'm not able to generate the scripts from SASS running the application locally, I'm having an issue regarding node/sass. I'm using Node v8.9.1/NPM 5.5.1 and windows 10 x64. But this is not the first time it happens so it should be an environment issue.

fixes https://github.com/moment/momentjs.com/issues/472