### PR TITLE
Add info about removed warning

### DIFF
--- a/guides/moment/02-warnings/03-parent-locale.md
+++ b/guides/moment/02-warnings/03-parent-locale.md
@@ -2,6 +2,6 @@
 title: Parent Locale Undefined
 ---
 
-Warnings removed since 2.16.0.
+Warnings removed since **2.16.0**.
 
 A locale can be defined with a parent before the parent itself is defined or loaded. If the parent doesn't exist or can't be lazy loaded when the moment is created, the parent will default to the global locale.

--- a/guides/moment/02-warnings/03-parent-locale.md
+++ b/guides/moment/02-warnings/03-parent-locale.md
@@ -2,6 +2,6 @@
 title: Parent Locale Undefined
 ---
 
-Warnings removed since **2.16.0**.
+Warning removed since **2.16.0**.
 
 A locale can be defined with a parent before the parent itself is defined or loaded. If the parent doesn't exist or can't be lazy loaded when the moment is created, the parent will default to the global locale.

--- a/guides/moment/02-warnings/03-parent-locale.md
+++ b/guides/moment/02-warnings/03-parent-locale.md
@@ -1,16 +1,7 @@
 ---
 title: Parent Locale Undefined
 ---
-```
-specified parentLocale is not defined yet
-```
 
-This warning is displayed when a locale is defined with a specified parent locale that does not exist.
+Warnings removed since 2.16.0.
 
-Because 'xyz' is not a locale, the following code will result in this warning:
-
-```javascript
-moment.defineLocale('fakeLocale', {parentLocale:'xyz'})
-```
-
-To fix this, choose a parent locale that is already defined. If you are defining a locale that will be the parent of another locale, make sure that your locales are defined in order.
+A locale can be defined with a parent before the parent itself is defined or loaded. If the parent doesn't exist or can't be lazy loaded when the moment is created, the parent will default to the global locale.


### PR DESCRIPTION
This warning was removed in 2.16.0 (see [this commit](https://github.com/moment/moment/commit/a83615a3dfdef0f4ddda3a4bcdfc90028e158d07#diff-6d534a0c3c9df392784bdfbc68d046b3))

However, an exception was thrown when using a moment defined with non existent parent. This bug was fixed in PR [#4310](https://github.com/moment/moment/pull/4310). This update to the documentation reflects this.
  
  