### PR TITLE
Update Customise parent locale

### DIFF
--- a/docs/moment/07-customization/00-intro.md
+++ b/docs/moment/07-customization/00-intro.md
@@ -31,6 +31,14 @@ moment.defineLocale('en-foo', {
 ```
 Properties that are not specified in the locale will be inherited from the parent locale.
 
+As of **2.16.0** it is possible to define a locale with a parent that hasn't itself been defined or loaded.
+
+```javascript
+moment.defineLocale('fakeLocale', {parentLocale:'xyz'})
+```
+
+As of **next moment version** when attempting to create a moment with the newly defined locale, moment will attempt to lazy load the parent if it exists. Failing that it will default the parent to the global locale.
+
 As of **2.12.0** it is also possible to update a locale's properties.
 
 ```javascript

--- a/docs/moment/07-customization/00-intro.md
+++ b/docs/moment/07-customization/00-intro.md
@@ -37,7 +37,7 @@ As of **2.16.0** it is possible to define a locale with a parent that hasn't its
 moment.defineLocale('fakeLocale', {parentLocale:'xyz'})
 ```
 
-As of **next moment version** when attempting to create a moment with the newly defined locale, moment will attempt to lazy load the parent if it exists. Failing that it will default the parent to the global locale.
+As of **2.21.0** when attempting to create a moment with the newly defined locale, moment will attempt to lazy load the parent if it exists. Failing that it will default the parent to the global locale.
 
 As of **2.12.0** it is also possible to update a locale's properties.
 


### PR DESCRIPTION
This adds the description of defining a locale with a parent that hasn't itself been defined or loaded yet which has been available since 2.16.0. This also describes the additional behavior when creating a moment of lazy loading the parent locale if it isn't already loaded, or defaulting to the global locale if the parent doesn't exist. See PR [#4310](https://github.com/moment/moment/pull/4310). As the next version number isn't determined yet, this should be merged only with the next release that includes the above PR.
  
  