### PR TITLE
Fix typo for the luxon URL

### DIFF
--- a/pages/layout/base.hbs
+++ b/pages/layout/base.hbs
@@ -34,7 +34,7 @@
 						</svg>
 						Moment<br/>Timezone
 					</a>
-                                        <a class="nav-project nav-project-luxon" href="https://moment.github.com/luxon">
+                                        <a class="nav-project nav-project-luxon" href="https://moment.github.io/luxon/">
                                           <svg width="40px" height="40px" viewBox="0 0 40 40">
                                             <g transform="translate(1.000000, 1.000000)">
                                               <ellipse stroke-width="3" fill-rule="nonzero" cx="19" cy="19" ry="18.5" rx="18.5"/>


### PR DESCRIPTION
1. To avoid unnecessary redirects:

- https://moment.github.com/luxon
    - => http://moment.github.io/luxon
        - => http://moment.github.io/luxon/

2. To keep the connection secure:

- (current) http://moment.github.io/luxon/
- (proposed) https://moment.github.io/luxon/