### PR TITLE
overflow: auto on top-level nav was hiding algolia-autocomplete

### DIFF
--- a/assets/css/common/_docs.scss
+++ b/assets/css/common/_docs.scss
@@ -11,7 +11,6 @@
 	padding: 20px;
 	font-size: 14px;
 	line-height: 18px;
-	overflow: auto;
 
 	.active a {
 		.is-moment & {
@@ -64,6 +63,7 @@
 
 .docs-nav-links {
 	overflow-y: auto;
+	height: 95%;
 }
 
 .docs-nav-item {


### PR DESCRIPTION
adding a height to .doc-nav-links achieves the overflow-y scroll effect without interfering with algolia listbox