### PR TITLE
correct invalid output

### DIFF
--- a/docs/moment/00-use-it/08-typescript.md
+++ b/docs/moment/00-use-it/08-typescript.md
@@ -37,7 +37,7 @@ import 'moment/locale/pt-br';
 
 console.log(moment.locale()); // en
 moment.locale('fr');
-console.log(moment.locale()); // en
+console.log(moment.locale()); // fr
 moment.locale('pt-BR');
 console.log(moment.locale()); // pt-BR
 ```


### PR DESCRIPTION
console.log(moment.locale()) should output fr after setting moment.locale('fr')