### PR TITLE
Add reference to Parsing Guide in Parsing Docs

### DIFF
--- a/docs/moment/01-parsing/00-intro.md
+++ b/docs/moment/01-parsing/00-intro.md
@@ -9,3 +9,4 @@ The `Moment` prototype is exposed through `moment.fn`. If you want to add your o
 
 For ease of reference, any method on the `Moment.prototype` will be referenced in the docs as `moment#method`. So `Moment.prototype.format` == `moment.fn.format` == `moment#format`.
 
+[See the Parsing Guide for additional information](https://momentjs.com/guides/#/parsing/)


### PR DESCRIPTION
PR to address some of the discussion in #4314

Adding a link to the parsing guide within the parsing docs to assist in explaining full usage