### PR TITLE
Mention that utcOffset is set on the object

### DIFF
--- a/docs/moment/03-manipulating/09-utc-offset.md
+++ b/docs/moment/03-manipulating/09-utc-offset.md
@@ -20,7 +20,8 @@ moment().utcOffset(); // (-240, -120, -60, 0, 60, 120, 240, etc.)
 ```
 
 Setting the UTC offset by supplying minutes. The offset is set on the moment object
-that `utcOffset()` is called on; it is not set globally. Note that once you set an offset,
+that `utcOffset()` is called on. If you are wanting to set the offset globally, 
+try using [moment-timezone](/timezone/). Note that once you set an offset,
 it's fixed and won't change on its own (i.e there are no DST rules). If you want
 an actual time zone -- time in a particular location, like
 `America/Los_Angeles`, consider [moment-timezone](/timezone/).

--- a/docs/moment/03-manipulating/09-utc-offset.md
+++ b/docs/moment/03-manipulating/09-utc-offset.md
@@ -19,7 +19,8 @@ Getting the `utcOffset` of the current object:
 moment().utcOffset(); // (-240, -120, -60, 0, 60, 120, 240, etc.)
 ```
 
-Setting the UTC offset by supplying minutes. Note that once you set an offset,
+Setting the UTC offset by supplying minutes. The offset is set on the moment object
+that `utcOffset()` is called on; it is not set globally. Note that once you set an offset,
 it's fixed and won't change on its own (i.e there are no DST rules). If you want
 an actual time zone -- time in a particular location, like
 `America/Los_Angeles`, consider [moment-timezone](/timezone/).


### PR DESCRIPTION
# What's in this PR?
[This issue](https://github.com/moment/moment/issues/4635) mentioned that it was not clear in the documentation that the `utcOffset` is not being set globally. I'm taking a crack at updating the related docs to mention this. @ichernev mentioned that it sounded like the reporter was most likely looking for functionality that is in `moment-timezone`. I did not mention anything about this in my update, as I think the sentence that follows covers that portion.

I don't think an example is _necessary_, but I am open to suggestions.

Let me know what you think 😄 

## Reference
- [4635](https://github.com/moment/moment/issues/4635)