### PR TITLE
#523 Style tables so they don't overflow anymore

### DIFF
--- a/assets/css/common/_docs.scss
+++ b/assets/css/common/_docs.scss
@@ -129,6 +129,7 @@
 	}
 
 	table {
+		table-layout: fixed;
 		width: 100%;
 		margin-bottom: 20px;
 	}
@@ -149,9 +150,11 @@
 	}
 
 	td:nth-of-type(1) {
-		white-space: pre;
-		text-align: right;
+		text-align: left;
 		width: 0;
+		code {
+			word-break: break-all;
+		}
 	}
 
 	td:last-of-type {
@@ -174,6 +177,8 @@
 			font-weight: bold;
 		}
 	}
+
+
 }
 
 .docs-section {


### PR DESCRIPTION
Added some styling to fix the issue that the table overflows.
Now there is a line break in the middle of the constant, but I think it's the only way to do it. There is a lot of information on one line here so it will always look a bit off.