### PR TITLE
Month typo

### DIFF
--- a/docs/moment/01-parsing/10-array.md
+++ b/docs/moment/01-parsing/10-array.md
@@ -37,5 +37,5 @@ If the date represented by the array does not exist, `moment#isValid` will retur
 ```javascript
 moment([2010, 12]).isValid();     // false (not a real month)
 moment([2010, 10, 31]).isValid(); // false (not a real day)
-moment([2010, 1, 29]).isValid();  // false (not a leap year)
+moment([2010, 2, 29]).isValid();  // false (not a leap year)
 ```


### PR DESCRIPTION
Correct the month value to Feb (2) on the leap year check example