### PR TITLE
Adjust language selection

### DIFF
--- a/data/locale.js
+++ b/data/locale.js
@@ -94,7 +94,7 @@ module.exports =[
     },
     {
         "abbr": "zh-cn",
-        "name": "Chinese (China)"
+        "name": "Chinese (Mainland)"
     },
     {
         "abbr": "zh-hk",


### PR DESCRIPTION
As the option of Simplified Chinese, 'Mainland' should be used here to be equivalent to Hong Kong and Taiwan.