### PR TITLE
Documentation for "ignoreCache" argument of moment.tz.guess()

### DIFF
--- a/docs/moment-timezone/01-using-timezones/06-guessing-user-timezone.md
+++ b/docs/moment-timezone/01-using-timezones/06-guessing-user-timezone.md
@@ -1,7 +1,7 @@
 ---
 title: Guessing user zone
 signature: |
-  moment.tz.guess();
+  moment.tz.guess(Boolean);
 ---
 
 
@@ -9,6 +9,14 @@ Moment Timezone uses the Internationalization API (`Intl.DateTimeFormat().resolv
 
 On other browsers, time zone detection is rather tricky to get right, as there is little information provided by those browsers. For those, it will use `Date#getTimezoneOffset` and `Date#toString` on a handful of moments around the current year to gather as much information about the browser environment as possible. It then compares that information with all the time zone data loaded and returns the closest match. In case of ties, the time zone with the city with largest population is returned.
 
+By default Moment Timezone caches the detected timezone. This means that subsequent calls to `moment.tz.guess()` will always return the same value.
+
+You can call `moment.tz.guess()` with an optional boolean argument "ignoreCache". If set to true, the cache will be ignored and overwritten with the new value.
+
 ```js
 moment.tz.guess(); // America/Chicago
+// the client's timezone changes to Europe/Berlin
+moment.tz.guess(); // America/Chicago
+moment.tz.guess(true); // Europe/Berlin
+moment.tz.guess(); // Europe/Berlin
 ```

--- a/docs/moment-timezone/01-using-timezones/06-guessing-user-timezone.md
+++ b/docs/moment-timezone/01-using-timezones/06-guessing-user-timezone.md
@@ -1,6 +1,7 @@
 ---
 title: Guessing user zone
 signature: |
+  moment.tz.guess();
   moment.tz.guess(Boolean);
 ---
 
@@ -15,7 +16,7 @@ You can call `moment.tz.guess()` with an optional boolean argument "ignoreCache"
 
 ```js
 moment.tz.guess(); // America/Chicago
-// the client's timezone changes to Europe/Berlin
+// suppose the client's timezone changes to Europe/Berlin
 moment.tz.guess(); // America/Chicago
 moment.tz.guess(true); // Europe/Berlin
 moment.tz.guess(); // Europe/Berlin


### PR DESCRIPTION
Added documentation for the "ignoreCache" argument of the function `moment.tz.guess()` as discussed in https://github.com/moment/momentjs.com/issues/550

fixes #550 