### PR TITLE
Use correct 12 hour clock format on timezone page

### DIFF
--- a/assets/js/timezone-home.js
+++ b/assets/js/timezone-home.js
@@ -50,7 +50,7 @@
 		activate : function () {
 			var m = moment().tz(this.name);
 			$labelName.text(this.name);
-			$labelTime.text(m.format("hh:mm a ") + m.zoneAbbr());
+			$labelTime.text(m.format("h:mm a ") + m.zoneAbbr());
 			$axisX.css('left', this.x * 100 + '%');
 			$axisY.css('top', this.y * 100 + '%');
 		},


### PR DESCRIPTION
On the [Moment Timezone homepage](https://momentjs.com/timezone/) the 12-hour clock on the world map is incorrectly formatted with a 2 digit hour `hh:mm a`.

[12-hour clocks](https://en.wikipedia.org/wiki/12-hour_clock) do not prefix `0` to the hour and should be formatted as `h:mm a`. The `0` prefix is used to indicate that the time is displayed in [24-hour format](https://en.wikipedia.org/wiki/24-hour_clock).

![screenshot 2019-01-31 at 13 37 49](https://user-images.githubusercontent.com/144435/52057851-0dc9e700-255e-11e9-9586-695883131e95.png)
