### PR TITLE
Fix some formatting problems

### DIFF
--- a/docs/moment-timezone/02-zone-object/00-intro.md
+++ b/docs/moment-timezone/02-zone-object/00-intro.md
@@ -10,6 +10,7 @@ on the `moment.tz.Zone` namespace.
 This object has 4 properties.
 
 <!-- skip-example -->
+
 ```js
 {
 	name    : 'America/Los_Angeles',          // the unique identifier

--- a/docs/moment-timezone/03-data-formats/01-unpacked-format.md
+++ b/docs/moment-timezone/03-data-formats/01-unpacked-format.md
@@ -7,6 +7,7 @@ The unpacked format looks exactly like the [zone object](#/zone-object/).
 The data below is for Los Angeles between 2014 and 2018.
 
 <!-- skip-example -->
+
 ```js
 {
 	name    : 'America/Los_Angeles',

--- a/docs/moment-timezone/04-data-loading/01-adding-a-zone.md
+++ b/docs/moment-timezone/04-data-loading/01-adding-a-zone.md
@@ -19,5 +19,5 @@ moment.tz.add([
 	'America/New_York|EST EDT|50 40|0101|1Lz50 1zb0 Op0'
 ]);
 ```
-** Note: The above zone data is sample data and is not up to date.
-Reference the [moment-timezone source](https://github.com/moment/moment-timezone/blob/develop/data/packed/latest.json) for up to date data. **
+**Note: The above zone data is sample data and is not up to date.
+Reference the [moment-timezone source](https://github.com/moment/moment-timezone/blob/develop/data/packed/latest.json) for up to date data.**

--- a/docs/moment-timezone/04-data-loading/03-loading-a-data-bundle.md
+++ b/docs/moment-timezone/04-data-loading/03-loading-a-data-bundle.md
@@ -16,6 +16,7 @@ The versions are named after the year and an incrementing letter. `2014a 2014b 2
 In order to keep versions together, Moment Timezone has a bundled object format as well.
 
 <!-- skip-example -->
+
 ```js
 {
 	version : '2014e',
@@ -33,6 +34,7 @@ In order to keep versions together, Moment Timezone has a bundled object format 
 To load a bundle into Moment Timezone, use `moment.tz.load`.
 
 <!-- skip-example -->
+
 ```js
 moment.tz.load({
 	version : '2014e',

--- a/docs/moment-timezone/05-data-utilities/05-create-links.md
+++ b/docs/moment-timezone/05-data-utilities/05-create-links.md
@@ -7,6 +7,7 @@ signature: |
 In order to reduce duplication, we can create links out of two zones that share data.
 
 <!-- skip-example -->
+
 ```js
 var unlinked = {
     zones : [

--- a/docs/moment-timezone/05-data-utilities/06-filter-years.md
+++ b/docs/moment-timezone/05-data-utilities/06-filter-years.md
@@ -11,6 +11,7 @@ from 1900 to 2038. The data for all these years may not be necessary for your us
 `moment.tz.filterYears` can be used to filter out data for years outside a certain range.
 
 <!-- skip-example -->
+
 ```js
 var all    = { name : "America/Los_Angeles", abbrs : [...], offsets : [...] untils : [...]};
 var subset = moment.tz.filterYears(all, 2012, 2016);
@@ -21,6 +22,7 @@ subset.untils.length; // 11
 If only one year is passed, it will be used for the start and end year.
 
 <!-- skip-example -->
+
 ```js
 var all    = { name : "America/Los_Angeles", abbrs : [...], offsets : [...] untils : [...]};
 var subset = moment.tz.filterYears(all, 2012);

--- a/docs/moment/00-use-it/04-require-js.md
+++ b/docs/moment/00-use-it/04-require-js.md
@@ -14,6 +14,7 @@ folder. Then you should use a tool like
 using [packages config](http://requirejs.org/docs/api.html#packages).
 
 <!-- skip-example -->
+
 ```javascript
 requirejs.config({
   packages: [{
@@ -30,6 +31,7 @@ With the above setup, you can require the core with `moment` and `de` locale
 with `moment/locale/de`.
 
 <!-- skip-example -->
+
 ```javascript
 // only needing core
 define(['moment'], function (moment) {
@@ -68,6 +70,7 @@ For more complicated use cases please read [excellent explanation by @jrburke](h
 Moment will still create a `moment` global, which is useful to plugins and other third-party code. If you wish to squash that global, use the `noGlobal` option on the module config.
 
 <!-- skip-example -->
+
 ```javascript
 require.config({
     config: {

--- a/docs/moment/00-use-it/08-webpack.md
+++ b/docs/moment/00-use-it/08-webpack.md
@@ -14,6 +14,7 @@ moment().format();
 **Note:** By default, webpack bundles _all_ Moment.js locales (in Moment.js 2.18.1, that’s 160 minified KBs). To strip unnecessary locales and bundle only the used ones, add [`moment-locales-webpack-plugin`](https://www.npmjs.com/package/moment-locales-webpack-plugin):
 
 <!-- skip-example -->
+
 ```javascript
 // webpack.config.js
 const MomentLocalesPlugin = require('moment-locales-webpack-plugin');

--- a/docs/moment/00-use-it/10-system-js.md
+++ b/docs/moment/00-use-it/10-system-js.md
@@ -6,6 +6,7 @@ To load moment, place it in the path specified by your System.config in the base
 Then import it into your page.
 
 <!-- skip-example -->
+
 ```js
 <script src="system.js"></script>
 <script>
@@ -21,6 +22,7 @@ Then import it into your page.
 If you need moment to be loaded as global, you can do this with the meta configuration:
 
 <!-- skip-example -->
+
 ```javascript
 System.config({
   meta: {
@@ -32,6 +34,7 @@ System.config({
 Alternatively, to provide Moment as a global to only a specific dependency, you can do this:
 
 <!-- skip-example -->
+
 ```javascript
 System.config({
   meta: {

--- a/docs/moment/01-parsing/16-creation-data.md
+++ b/docs/moment/01-parsing/16-creation-data.md
@@ -9,6 +9,7 @@ After a moment object is created, all of the inputs can be accessed with
 `creationData()` method:
 
 <!-- skip-example -->
+
 ```javascript
 moment("2013-01-02", "YYYY-MM-DD", true).creationData() === {
     input: "2013-01-02",

--- a/docs/moment/07-customization/07-relative-time.md
+++ b/docs/moment/07-customization/07-relative-time.md
@@ -47,6 +47,7 @@ If a locale requires additional processing for a token, it can set the token as 
 The function should return a string.
 
 <!-- skip-example -->
+
 ```javascript
 function (number, withoutSuffix, key, isFuture) {
     return string;

--- a/pages/partials/docs-partial.hbs
+++ b/pages/partials/docs-partial.hbs
@@ -52,7 +52,7 @@
 								{{#markdown}}```js{{{ signature }}}```{{/markdown}}
 							</div>
 						{{/if}}
-						{{#markdown}}
+						{{#markdown breaks=false}}
 							{{{body}}}
 						{{/markdown}}
 					</div>


### PR DESCRIPTION
The markdown renderer used by the docs has a [bug with handling HTML comments](https://github.com/jonschlinkert/remarkable/issues/209). This resulted in some code examples not properly rendering as code blocks. While fixing these, I also noticed some other minor formatting problems caused by the markdown renderer's default settings.

This PR contains the following changes:

* Ensure a blank line following all `<!-- skip-example -->` comments, to make sure the code samples are rendered correctly.
* Update whitespace in a note that was using **bold** formatting, but wasn't being rendered as bold.
* Add `breaks=false` option for docs pages. By default there are line breaks (`<br />`) being inserted in the rendered HTML based on line breaks in the markdown source files. This was causing some strange formatting in the HTML.
  <details><summary>Example...</summary>
  <img width="764" alt="image" src="https://user-images.githubusercontent.com/159415/52183035-05242a00-2858-11e9-8dc7-b93ac9644eec.png">
  </details>

I didn't add `breaks=false` to the guides section, as it appeared that the line breaks there were more strategic and intentional.

My primary purpose was to fix the code examples. If the line break change isn't desired, I can remove it.

Some screenshots:

<details><summary>Before</summary>

![screen shot 2019-02-04 at 08 35 47](https://user-images.githubusercontent.com/159415/52183074-65b36700-2858-11e9-9d4a-281174c8d6d1.png)

</details>

<details><summary>After</summary>

![screen shot 2019-02-04 at 08 36 17](https://user-images.githubusercontent.com/159415/52183077-6cda7500-2858-11e9-9856-1f66ee090d1f.png)

</details>
