### PR TITLE
Updated duration documentation to address ISO/RFC violation (Issue #4815 on moment)

### DIFF
--- a/docs/moment/08-durations/04-milliseconds.md
+++ b/docs/moment/08-durations/04-milliseconds.md
@@ -24,3 +24,5 @@ moment.duration(500).asMilliseconds(); // 500
 moment.duration(1500).asMilliseconds(); // 1500
 moment.duration(15000).asMilliseconds(); // 15000
 ```
+
+Note that both `moment.duration().milliseconds()` and `moment.duration().asMilliseconds()` return output that does not meet the ISO 8601 *nominal duration* or the RFC 5545 *duration* standards.

--- a/docs/moment/08-durations/05-seconds.md
+++ b/docs/moment/08-durations/05-seconds.md
@@ -24,3 +24,5 @@ moment.duration(500).asSeconds(); // 0.5
 moment.duration(1500).asSeconds(); // 1.5
 moment.duration(15000).asSeconds(); // 15
 ```
+
+Note that both `moment.duration().seconds()` and `moment.duration().asSeconds()` return output that does not meet the ISO 8601 *nominal duration* or the RFC 5545 *duration* standards.

--- a/docs/moment/08-durations/06-minutes.md
+++ b/docs/moment/08-durations/06-minutes.md
@@ -10,3 +10,5 @@ signature: |
 As with the other getters for durations, `moment.duration().minutes()` gets the minutes (0 - 59).
 
 `moment.duration().asMinutes()` gets the length of the duration in minutes.
+
+Note that both `moment.duration().minutes()` and `moment.duration().asMinutes()` return output that does not meet the ISO 8601 *nominal duration* or the RFC 5545 *duration* standards.

--- a/docs/moment/08-durations/07-hours.md
+++ b/docs/moment/08-durations/07-hours.md
@@ -10,3 +10,5 @@ signature: |
 As with the other getters for durations, `moment.duration().hours()` gets the hours (0 - 23).
 
 `moment.duration().asHours()` gets the length of the duration in hours.
+
+Note that both `moment.duration().hours()` and `moment.duration().asHours()` return output that does not meet the ISO 8601 *nominal duration* or the RFC 5545 *duration* standards.

--- a/docs/moment/08-durations/08-days.md
+++ b/docs/moment/08-durations/08-days.md
@@ -10,3 +10,5 @@ signature: |
 As with the other getters for durations, `moment.duration().days()` gets the days (0 - 30).
 
 `moment.duration().asDays()` gets the length of the duration in days.
+
+Note that both `moment.duration().days()` and `moment.duration().asDays()` return output that does not meet the ISO 8601 *nominal duration* or the RFC 5545 *duration* standards.

--- a/docs/moment/08-durations/09-weeks.md
+++ b/docs/moment/08-durations/09-weeks.md
@@ -14,3 +14,5 @@ As with the other getters for durations, `moment.duration().weeks()` gets the we
 Pay attention that unlike the other getters for duration, weeks are counted as a subset of the days, and are not taken off the days count.
 
 **Note:** The length of a duration in weeks is defined as 7 days.
+
+Also note that both `moment.duration().weeks()` and `moment.duration().asWeeks()` return output that does not meet the ISO 8601 *nominal duration* or the RFC 5545 *duration* standards.

--- a/docs/moment/08-durations/10-months.md
+++ b/docs/moment/08-durations/10-months.md
@@ -10,3 +10,5 @@ signature: |
 As with the other getters for durations, `moment.duration().months()` gets the months (0 - 11).
 
 `moment.duration().asMonths()` gets the length of the duration in months.
+
+Note that both `moment.duration().months()` and `moment.duration().asMonths()` return output that does not meet the ISO 8601 *nominal duration* or the RFC 5545 *duration* standards.

--- a/docs/moment/08-durations/11-years.md
+++ b/docs/moment/08-durations/11-years.md
@@ -10,3 +10,5 @@ signature: |
 As with the other getters for durations, `moment.duration().years()` gets the years.
 
 `moment.duration().asYears()` gets the length of the duration in years.
+
+Note that both `moment.duration().years()` and `moment.duration().asYears()` return output that does not meet the ISO 8601 *nominal duration* or the RFC 5545 *duration* standards.


### PR DESCRIPTION
As per [issue #4815](https://github.com/moment/moment/issues/4815) on the moment repository, I updated the documentation on duration to note that the output of certain functions violates ISO 8601 and RFC 5545.