### PR TITLE
Update comments in typescript style imports doc

### DIFF
--- a/docs/moment/00-use-it/09-typescript.md
+++ b/docs/moment/00-use-it/09-typescript.md
@@ -48,7 +48,7 @@ import 'moment/locale/pt-br';
 
 console.log(moment.locale()); // en
 moment.locale('fr');
-console.log(moment.locale()); // en
+console.log(moment.locale()); // fr
 moment.locale('pt-BR');
 console.log(moment.locale()); // pt-BR
 ```


### PR DESCRIPTION
`moment.locale('fr')` 
will change locale to `'fr'` and then 
`console.log(moment.locale())` will display `'fr'`.  In comments it is a typo - `en`, which is corrected now. This may be very small but can create confusion