### PR TITLE
Fix TypeScript import style

### DIFF
--- a/docs/moment/00-use-it/09-typescript.md
+++ b/docs/moment/00-use-it/09-typescript.md
@@ -14,20 +14,14 @@ Import and use in your Typescript file
 <!-- skip-example -->
 
 ```javascript
-import * as moment from 'moment';
+import moment = require('moment');
 
 let now = moment().format('LLLL');
 ```
 
 **Note:** If you have trouble importing moment
 
-For _Typescript 2.x_ try adding ```"moduleResolution": "node"``` in ```compilerOptions``` in your ```tsconfig.json``` file and then use any of the below syntax
-<!-- skip-example -->
-
-```javascript
-import * as moment from 'moment';
-import moment = require('moment');
-```
+For _Typescript 2.x_ try adding ```"moduleResolution": "node"``` in ```compilerOptions``` in your ```tsconfig.json``` file
 
 For _Typescript 1.x_ try adding ```"allowSyntheticDefaultImports": true``` in ```compilerOptions``` in your ```tsconfig.json``` file and then use the syntax
 <!-- skip-example -->


### PR DESCRIPTION
When importing a package that has been exported as a single function, you should do:

    import moment = require("moment");

There is an explanation here from Ryan Cavanaugh, the TypeScript development lead, about why this is the case: https://stackoverflow.com/a/35706271/1916362

To summarise:

> Attempting to use `import * as express` and then invoking `express()` is always illegal according to the ES6 spec. In some runtime+transpilation environments this might happen to work anyway, but it might break at any point in the future without warning

This PR updates the docs to be in line with best TypeScript practices