### PR TITLE
require-js: fix typo in "acquired"

### DIFF
--- a/docs/moment/00-use-it/04-require-js.md
+++ b/docs/moment/00-use-it/04-require-js.md
@@ -7,7 +7,7 @@ We strongly recommend reading
 if you plan to use moment with Require.js. Also upgrade to **2.14.0** or above
 for best experience.
 
-As a start, you might have aquired moment through bower or node_modules or
+As a start, you might have acquired moment through bower or node_modules or
 anything else that places moment.js together with a locales directory in a base
 folder. Then you should use a tool like
 [adapt-pkg-main](https://github.com/jrburke/adapt-pkg-main), or manually --


### PR DESCRIPTION
"aquired" is not a dictionary word - I think what you want is "acquired". :)