### PR TITLE
Update 00-intro.md

### DIFF
--- a/docs/moment-timezone/01-using-timezones/00-intro.md
+++ b/docs/moment-timezone/01-using-timezones/00-intro.md
@@ -25,8 +25,8 @@ Note that created moments have different UTC time because these moments were cre
 
 
 ```js
-var a = moment("2013-11-18 11:55").tz("Asia/Taipei");
-var b = moment("2013-11-18 11:55").tz("America/Toronto");
+var a = moment.utc("2013-11-18 11:55").tz("Asia/Taipei");
+var b = moment.utc("2013-11-18 11:55").tz("America/Toronto");
    
 a.format(); // 2013-11-18T19:55:00+08:00
 b.format(); // 2013-11-18T06:55:00-05:00

--- a/docs/moment-timezone/01-using-timezones/00-intro.md
+++ b/docs/moment-timezone/01-using-timezones/00-intro.md
@@ -36,5 +36,5 @@ b.utc().format(); // 2013-11-18T11:55Z
 ```
 
 In this example, you first create `moment.utc("2013-11-18 11:55")` object in UTC, and then change its timezone to specified. This also works if you create the object in your default timezone: `moment("2013-11-18 11:55")`.
-  
+
 Note that created moments have equal UTC time because these moments were created in a [default timezone](#/using-timezones/default-timezone/).

--- a/docs/moment-timezone/01-using-timezones/00-intro.md
+++ b/docs/moment-timezone/01-using-timezones/00-intro.md
@@ -35,6 +35,6 @@ a.utc().format(); // 2013-11-18T11:55Z
 b.utc().format(); // 2013-11-18T11:55Z
 ```
 
-In this example, you first create `moment("2013-11-18 11:55")` object in your default timezone, and then change its timezone to specified. 
+In this example, you first create `moment.utc("2013-11-18 11:55")` object in UTC, and then change its timezone to specified. This also works if you create the object in your default timezone: `moment("2013-11-18 11:55")`.
   
 Note that created moments have equal UTC time because these moments were created in a [default timezone](#/using-timezones/default-timezone/).

--- a/docs/moment-timezone/01-using-timezones/00-intro.md
+++ b/docs/moment-timezone/01-using-timezones/00-intro.md
@@ -27,7 +27,7 @@ Note that created moments have different UTC time because these moments were cre
 ```js
 var a = moment.utc("2013-11-18 11:55").tz("Asia/Taipei");
 var b = moment.utc("2013-11-18 11:55").tz("America/Toronto");
- 
+
 a.format(); // 2013-11-18T19:55:00+08:00
 b.format(); // 2013-11-18T06:55:00-05:00
 


### PR DESCRIPTION
If the datetime passed into the constructor doesn't contain `Z`, `.utc` should be used.
Otherwise everyone will see another value for `a.format()` and `b.format()`
This is source of confusion.

https://codesandbox.io/embed/gifted-jennings-gnxtr