### PR TITLE
Add note to updateLocale

### DIFF
--- a/docs/moment/07-customization/00-intro.md
+++ b/docs/moment/07-customization/00-intro.md
@@ -47,7 +47,7 @@ moment.updateLocale('en', {
 });
 ```
 
-Any properties specified will be updated, while others will remain the same. This function does not affect moments that already exist.
+Any properties specified will be updated, while others will remain the same. This function does not affect moments that already exist. Not that calling `updateLocale` also sets the current global locale to that locale.
 
 To revert an update use:
 ```javascript

--- a/docs/moment/07-customization/00-intro.md
+++ b/docs/moment/07-customization/00-intro.md
@@ -47,7 +47,7 @@ moment.updateLocale('en', {
 });
 ```
 
-Any properties specified will be updated, while others will remain the same. This function does not affect moments that already exist. Not that calling `updateLocale` also sets the current global locale to that locale.
+Any properties specified will be updated, while others will remain the same. This function does not affect moments that already exist. Note that calling `updateLocale` also changes the current global locale, to the locale that is updated.
 
 To revert an update use:
 ```javascript

--- a/docs/moment/07-customization/00-intro.md
+++ b/docs/moment/07-customization/00-intro.md
@@ -47,7 +47,7 @@ moment.updateLocale('en', {
 });
 ```
 
-Any properties specified will be updated, while others will remain the same. This function does not affect moments that already exist. Note that calling `updateLocale` also changes the current global locale, to the locale that is updated.
+Any properties specified will be updated, while others will remain the same. This function does not affect moments that already exist. Note that calling `updateLocale` also changes the current global locale, to the locale that is updated; see [this GitHub issue](https://github.com/moment/moment/issues/5410) for more information.
 
 To revert an update use:
 ```javascript


### PR DESCRIPTION
### Motivation
We recently discovered an issue where formatting using `L` was returning the `DD/MM/YYYY` format, not the `MM/DD/YYYY` format expected in the `en` default. After some investigation, I discovered that this was being caused by calling `updateLocale` - our use of `moment` includes customizing the date format for a couple specific languages. To find this I had to check the source code, as it was not clear from the documentation that calling `updateLocale` changes the global locale.

### In this PR
- Added a note to the documentation for `updateLocale`, explaining that it sets the global locale.