### PR TITLE
Trim whitespace on home page examples to remove `undefined` lines

### DIFF
--- a/assets/js/core-home.js
+++ b/assets/js/core-home.js
@@ -45,8 +45,8 @@
     function Snippet (el) {
         var longest = 0,
             i,
-            text  = this.text  = el.text().split('\n'),
-            html  = this.html  = el.html().split('\n'),
+            text  = this.text  = el.text().trim().split('\n'),
+            html  = this.html  = el.html().trim().split('\n'),
             evals = this.evals = [];
 
         this.el = el;


### PR DESCRIPTION
Fixes #578

Before:

![image](https://user-images.githubusercontent.com/159415/59906006-f2973f80-944a-11e9-8f0f-48cf7059bc09.png)

After:

![image](https://user-images.githubusercontent.com/159415/59906046-05117900-944b-11e9-9030-396227f6b3d0.png)
