### PR TITLE
Add instructions for using moment-timezone with webpack

### DIFF
--- a/docs/moment-timezone/00-use-it/04-webpack.md
+++ b/docs/moment-timezone/00-use-it/04-webpack.md
@@ -1,0 +1,38 @@
+---
+title: Webpack
+signature: |
+  npm install moment-timezone
+---
+
+```javascript
+var moment = require('moment-timezone');
+moment().tz("America/Los_Angeles").format();
+```
+
+**Note:** By default, webpack bundles _all_ moment-timezone data (in moment-timezone 0.5.25, that’s over 900 KBs minified). To strip out unwanted data and bundle only the zone and date range data you need, add the [`moment-timezone-data-webpack-plugin`](https://www.npmjs.com/package/moment-timezone-data-webpack-plugin) package:
+
+<!-- skip-example -->
+
+```javascript
+// webpack.config.js
+const MomentTimezoneDataPlugin = require('moment-timezone-data-webpack-plugin');
+const currentYear = new Date().getFullYear();
+
+module.exports = {
+    plugins: [
+        // To include only specific zones, use the matchZones option
+        new MomentTimezoneDataPlugin({
+            matchZones: /^America/
+        }),
+
+        // To keep all zones but limit data to specific years, use the year range options
+        new MomentTimezoneDataPlugin({
+            startYear: currentYear - 5,
+            endYear: currentYear + 5,
+        }),
+    ],
+};
+```
+
+Also see the primary [Moment.js Webpack documentation](https://momentjs.com/docs/#/use-it/webpack/) for an example of how to reduce Moment’s bundled locale data.
+Together these techniques can significantly reduce the final bundle size (by over 1 MB minified, or 85 KB minified + gzipped).


### PR DESCRIPTION
This is pretty much a copy of the webpack usage docs at https://momentjs.com/docs/#/use-it/webpack, but with a different note about how to reduce the size of the bundled data.

This partially resolves https://github.com/moment/moment-timezone/issues/715, but doesn't mention the ES module syntax. I figured that adding ES usage should be a separate pull request, as it affects more than just webpack usage.

(Disclosure: I wrote the webpack plugin that’s mentioned in the page, so this is sort-of self promotion...)