### PR TITLE
Added new CDN - PageCDN

### DIFF
--- a/docs/moment/00-use-it/02-browser.md
+++ b/docs/moment/00-use-it/02-browser.md
@@ -10,4 +10,4 @@ title: Browser
 </script>
 ```
 
-Moment.js is available on [cdnjs.com](https://cdnjs.com/libraries/moment.js) and on [jsDelivr](https://www.jsdelivr.com/package/npm/moment).
+Moment.js is available on [PageCDN](https://pagecdn.com/lib/moment.js), [cdnjs.com](https://cdnjs.com/libraries/moment.js) and on [jsDelivr](https://www.jsdelivr.com/package/npm/moment).


### PR DESCRIPTION
PageCDN uses brotli-11 compression that reduces moment.js file size by more than 11 KBs compared to other CDNs. In addition, immutable caching is enabled by default to optimize content delivery a little more aggressively. This will make PageCDN a valuable addition to the documentation.

Thanks.