### PR TITLE
Updated ms precision in time offset token table

### DIFF
--- a/docs/moment/01-parsing/03-string-format.md
+++ b/docs/moment/01-parsing/03-string-format.md
@@ -87,16 +87,16 @@ LLLL`. They were added in version **2.2.1**, except `LTS` which was added
 
 *Tokens are case-sensitive.*
 
-| Input          | Example  | Description |
-| -------------- | -------- | ----------- |
-| `H HH`         | `0..23`  | Hours (24 hour time) |
-| `h hh`         | `1..12`  | Hours (12 hour time used with `a A`.) |
-| `k kk`         | `1..24`  | Hours (24 hour time from 1 to 24) |
-| `a A`          | `am pm`  | Post or ante meridiem (Note the one character `a p` are also considered valid) |
-| `m mm`         | `0..59`  | Minutes |
-| `s ss`         | `0..59`  | Seconds |
-| `S SS SSS`     | `0..999` | Fractional seconds |
-| `Z ZZ`         | `+12:00` | Offset from UTC as `+-HH:mm`, `+-HHmm`, or `Z` |
+| Input                    | Example        | Description |
+| ------------------------ | -------------- | ----------- |
+| `H HH`                   | `0..23`        | Hours (24 hour time) |
+| `h hh`                   | `1..12`        | Hours (12 hour time used with `a A`.) |
+| `k kk`                   | `1..24`        | Hours (24 hour time from 1 to 24) |
+| `a A`                    | `am pm`        | Post or ante meridiem (Note the one character `a p` are also considered valid) |
+| `m mm`                   | `0..59`        | Minutes |
+| `s ss`                   | `0..59`        | Seconds |
+| `S SS SSS ... SSSSSSSSS` | `0..999999999` | Fractional seconds |
+| `Z ZZ`                   | `+12:00`       | Offset from UTC as `+-HH:mm`, `+-HHmm`, or `Z` |
 
 From version **2.10.5**: fractional second tokens length 4 up to 9 can parse
 any number of digits, but will only consider the top 3 (milliseconds). Use if
@@ -113,6 +113,8 @@ For example, `.12` is always 120 milliseconds, passing `SS` will not cause it to
 `S SS SSS` were added in version **1.6.0**.
 
 `X` was added in version **2.0.0**.
+
+`SSSSS ... SSSSSSSSS` were added in version **2.10.5**.
 
 `k kk` was added in version **2.18.0**
 


### PR DESCRIPTION
The documentation does not specify the correct range of tokens allowed to represent fractional seconds. I have updated the table to reflect the current format token regex. If you'd prefer a slightly different formatting, I'm happy to tweak my proposal. Cheers!

- Updated time offset token table to with full fractional second precision range.
- Added "added in version" line for when Moment first supported five to nine digits of fractional second precision https://github.com/moment/moment/commit/3764d5aec34469cc00e4eaa3b467fe6688967761.