### PR TITLE
Corrected `k kk` "added in version" line

### DIFF
--- a/docs/moment/01-parsing/03-string-format.md
+++ b/docs/moment/01-parsing/03-string-format.md
@@ -114,7 +114,7 @@ For example, `.12` is always 120 milliseconds, passing `SS` will not cause it to
 
 `X` was added in version **2.0.0**.
 
-`k kk` was added in version **2.18.0**
+`k kk` were added in version **2.13.0**.
 
 Unless you specify a time zone offset, parsing a string will create a date in the current time zone.
 


### PR DESCRIPTION
Corrected `k kk` "added in version" line's release version per https://github.com/moment/moment/commit/46093762bd4fcd7dde7ed84151ff55605465ab17.
Minor edit, formatted `k kk` "added in version" line to be consistent with other lines.