### PR TITLE
Language in comment should be fr instead of en.

### DIFF
--- a/docs/moment/00-use-it/09-typescript.md
+++ b/docs/moment/00-use-it/09-typescript.md
@@ -48,7 +48,7 @@ import 'moment/locale/pt-br';
 
 console.log(moment.locale()); // en
 moment.locale('fr');
-console.log(moment.locale()); // en
+console.log(moment.locale()); // fr
 moment.locale('pt-BR');
 console.log(moment.locale()); // pt-BR
 ```


### PR DESCRIPTION
Language in comment should be fr instead of en. Just a small typo.