### PR TITLE
Update moment-timezone to 0.5.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10655,9 +10655,9 @@
       "dev": true
     },
     "moment-timezone": {
-      "version": "0.5.25",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.25.tgz",
-      "integrity": "sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==",
+      "version": "0.5.27",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.27.tgz",
+      "integrity": "sha512-EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==",
       "dev": true,
       "requires": {
         "moment": ">= 2.9.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "load-grunt-tasks": "^0.4.0",
     "markdown-doctest": "^0.7.0",
     "moment": "2.24.0",
-    "moment-timezone": "0.5.25",
+    "moment-timezone": "0.5.27",
     "time-grunt": "^0.3.1"
   }
 }


### PR DESCRIPTION
The page is still using 0.5.25 which incorrectly shows Sao Paolo as GMT-2.  The update includes the latest timezone data after Brazil cancelled DST.