### PR TITLE
Fixed documentation for 2nd parameter of zonesForCountry() method.

### DIFF
--- a/docs/moment-timezone/01-using-timezones/08-getting-country-zones.md
+++ b/docs/moment-timezone/01-using-timezones/08-getting-country-zones.md
@@ -2,7 +2,7 @@
 title: Getting Zones for country
 signature: |
   moment.tz.zonesForCountry(String); // String[]
-  moment.tz.zonesForCountry(String, { offset: true });
+  moment.tz.zonesForCountry(String, Boolean);
 ---
 
 To get a list of time zones for some country, use `moment.tz.zonesForCountry()`.
@@ -17,10 +17,10 @@ By default this method returns zone names sorted alphabetically:
 ["America/Adak", "America/Anchorage", ... "Pacific/Honolulu"]
 ```
 
-To get also offsets, pass `{ offset: true }` as 2nd parameter:
+To get also offsets, pass `true` as 2nd parameter:
 
 ```js
-moment.tz.zonesForCountry('CN', { offset: true });
+moment.tz.zonesForCountry('CN', true);
 ```
 
 it returns array of objects with name and offset:


### PR DESCRIPTION
The second parameter to zonesForCountry() method does not take an object, but instead takes in a bool. See: https://github.com/moment/moment-timezone/blob/0.5.28/moment-timezone.js#L503