### PR TITLE
Document support for YYYYMM ISO string

### DIFF
--- a/docs/moment/01-parsing/02-string.md
+++ b/docs/moment/01-parsing/02-string.md
@@ -30,10 +30,11 @@ An ISO 8601 string requires a date part.
 2013-039    # An ordinal date part
 
 20130208    # Basic (short) full date
+201303      # Basic (short) year+month
+2013        # Basic (short) year only
 2013W065    # Basic (short) week, weekday
 2013W06     # Basic (short) week only
-2013050     # Basic (short) ordinal date
-2013        # Basic (short) year only
+2013050     # Basic (short) ordinal date (year + day-of-year)
 ```
 
 A time part can also be included, separated from the date part by a space or an uppercase T.


### PR DESCRIPTION
As implemented in https://github.com/moment/moment/pull/5458