### PR TITLE
Fix wrong result of 'LT', 'LTS'

### DIFF
--- a/docs/moment/01-parsing/03-string-format.md
+++ b/docs/moment/01-parsing/03-string-format.md
@@ -91,8 +91,8 @@ LLLL`. They were added in version **2.2.1**, except `LTS` which was added
 | `LL`           | `September 4 1986`                    | Month name, day of month, year
 | `LLL`          | `September 4 1986 8:30 PM`            | Month name, day of month, year, time|
 | `LLLL`         | `Thursday, September 4 1986 8:30 PM`  | Day of week, month name, day of month, year, time	 |
-| `LT`           | `08:30 PM`                            | Time (without seconds) |
-| `LTS`          | `08:30:00 PM`                         | Time (with seconds) |
+| `LT`           | `8:30 PM`                            | Time (without seconds) |
+| `LTS`          | `8:30:00 PM`                         | Time (with seconds) |
 
 #### Hour, minute, second, millisecond, and offset tokens
 


### PR DESCRIPTION
In my case, 'LT' and 'LTS' returns H format instead of HH format.
```
var lt = moment().format('LT');
var lts = moment().format)('LTS');
console.log(lt); // Result : "7:23 PM"
console.log(lts); // Result : "7:23:54 PM"
```