### PR TITLE
Removes  <!-- skip-example --> from docs

### DIFF
--- a/docs/moment/00-use-it/01-node-js.md
+++ b/docs/moment/00-use-it/01-node-js.md
@@ -12,7 +12,6 @@ var moment = require('moment'); // require
 moment().format(); 
 ```
 Or in ES6 syntax:
- <!-- skip-example --> 
 ```javascript
 import moment from 'moment';
 moment().format();
@@ -20,7 +19,6 @@ moment().format();
 
 Note: if you want to work with a particular variation of moment timezone, for example using only data from 2012-2022, you will need to import it from the `builds` directory like so:
 
-<!-- skip-example --> 
  ```javascript
 import moment from 'moment-timezone/builds/moment-timezone-with-data-2012-2022';
 ```


### PR DESCRIPTION
Using  <!-- skip-example --> before the code block makes the format to not display on the Moment.js docs page
<img width="747" alt="Screen Shot 2020-06-09 at 15 54 00" src="https://user-images.githubusercontent.com/16366297/84198693-88b3e380-aa69-11ea-8873-b1db843821a8.png">
