### PR TITLE
markdown formatting with usages of "javascript"

### DIFF
--- a/docs/moment/00-use-it/01-node-js.md
+++ b/docs/moment/00-use-it/01-node-js.md
@@ -7,13 +7,13 @@ title: Node.js
 npm install moment
 ```
 
-```javascript
+```
 var moment = require('moment'); // require
 moment().format(); 
 ```
 Or in ES6 syntax:
  <!-- skip-example --> 
-```javascript
+```
 import moment from 'moment';
 moment().format();
 ```
@@ -21,7 +21,7 @@ moment().format();
 Note: if you want to work with a particular variation of moment timezone, for example using only data from 2012-2022, you will need to import it from the `builds` directory like so:
 
 <!-- skip-example --> 
- ```javascript
+ ```
 import moment from 'moment-timezone/builds/moment-timezone-with-data-2012-2022';
 ```
 


### PR DESCRIPTION
usage of ```javascript``` in markdown code snippets works in github previews but breaks the formatting used in the docs themselves on https://momentjs.com/docs. Other code snippets in the docs do not use this syntax and therefore for consistency and to fix the broken formatting on the docs site, this snippet should remove the above formatting.

<img width="790" alt="Screenshot 2020-06-10 at 10 19 02" src="https://user-images.githubusercontent.com/619506/84250848-7a66d580-ab04-11ea-8fb5-1975c625d1c5.png">