### PR TITLE
Add link to a list of Black Lives Matter charities

### DIFF
--- a/pages/moment/index.hbs
+++ b/pages/moment/index.hbs
@@ -139,6 +139,8 @@ moment().format('llll');
 
 Some Moment.js users may have a little extra money. Please support these charities:
 
+## A list of charities can be found [here](https://blacklives.help)
+
 ### [Black Lives Matter Foundation](https://secure.actblue.com/donate/ms_blm_homepage_2019)
 ### [Equal Justice Initiative](https://support.eji.org/give/153413/#!/donation/checkout)
 ### [Innocence Project](https://www.innocenceproject.org/donate/)

--- a/pages/moment/index.hbs
+++ b/pages/moment/index.hbs
@@ -139,8 +139,6 @@ moment().format('llll');
 
 Some Moment.js users may have a little extra money. Please support these charities:
 
-## A list of charities can be found [here](https://blacklives.help)
-
 ### [Black Lives Matter Foundation](https://secure.actblue.com/donate/ms_blm_homepage_2019)
 ### [Equal Justice Initiative](https://support.eji.org/give/153413/#!/donation/checkout)
 ### [Innocence Project](https://www.innocenceproject.org/donate/)
@@ -148,6 +146,8 @@ Some Moment.js users may have a little extra money. Please support these chariti
 ### [Minnesota Freedom Fund](https://minnesotafreedomfund.org/donate)
 ### [NAACP Legal Defense &amp; Education Fund](https://org2.salsalabs.com/o/6857/p/salsa/donation/common/public/?donate_page_KEY=15780)
 ### [Human Rights Watch](https://donate.hrw.org/page/15328/donate/1)
+
+[Here is a list](https://blacklives.help/) of related organizations you can support.
 
 {{/markdown}}
 


### PR DESCRIPTION
Added a link to https://blacklives.help, a website where users can donate to BlackLivesMatter charities and sign petitions.

In full disclosure, I am part of the team that developed the site. I am only adding it here because we noticed the message on your homepage (as we use Moment in our website), and thought it might be a good idea to link to a slightly longer list of potential causes & fundraisers. We don't make any commissions or gain personal benefit from operating the site; we operate under the non-profit organisation [CodeDdraig](https://codedragon.org/legal).

Thanks for your time.