### PR TITLE
Fix links to moment.min and moment.max in the documentation

### DIFF
--- a/docs/moment/03-manipulating/05-max.md
+++ b/docs/moment/03-manipulating/05-max.md
@@ -5,7 +5,7 @@ signature: |
   moment().max(Moment|String|Number|Date|Array);
 ---
 
-**Note:** This function has been **deprecated** in **2.7.0**. Consider [`moment.min`](/docs/#/get-set/min/) instead.
+**Note:** This function has been **deprecated** in **2.7.0**. Consider [`moment.max`](/docs/#/get-set/max/) instead.
 
 ------
 

--- a/docs/moment/03-manipulating/06-min.md
+++ b/docs/moment/03-manipulating/06-min.md
@@ -5,7 +5,7 @@ signature: |
   moment().min(Moment|String|Number|Date|Array);
 ---
 
-**Note:** This function has been **deprecated** in **2.7.0**. Consider [`moment.max`](/docs/#/get-set/max/) instead.
+**Note:** This function has been **deprecated** in **2.7.0**. Consider [`moment.min`](/docs/#/get-set/min/) instead.
 
 ------
 


### PR DESCRIPTION
The links to min and max in the depreciated note seem to have been switched at some point.  Now they'll send you to the correct page.

Hope I'm doing this right, since I've never made a PR before :)