### PR TITLE
Updated example for locale aware format "L"

### DIFF
--- a/docs/moment/01-parsing/03-string-format.md
+++ b/docs/moment/01-parsing/03-string-format.md
@@ -87,7 +87,7 @@ LLLL`. They were added in version **2.2.1**, except `LTS` which was added
 
 | Input          | Example                               | Description |
 | -------------- | ------------------------------------- | ----------- |
-| `L`            | `04/09/1986`                          | Date (in local format) |
+| `L`            | `09/04/1986`                          | Date (in local format) |
 | `LL`           | `September 4 1986`                    | Month name, day of month, year
 | `LLL`          | `September 4 1986 8:30 PM`            | Month name, day of month, year, time|
 | `LLLL`         | `Thursday, September 4 1986 8:30 PM`  | Day of week, month name, day of month, year, time	 |


### PR DESCRIPTION
Assuming this documentation shows uses the "en" locale globally, the output for .format("L") is actually MM/DD/YYYY and not DD/MM/YYYY.

Please do correct me if I am wrong, I've tested this on chrome + chrome canary and firefox.