### PR TITLE
Update 09-typescript.md fixed a typo

### DIFF
--- a/docs/moment/00-use-it/09-typescript.md
+++ b/docs/moment/00-use-it/09-typescript.md
@@ -14,7 +14,7 @@ Import and use in your Typescript file
 <!-- skip-example -->
 
 ```javascript
-import moment = require('moment');
+const moment = require('moment');
 
 let now = moment().format('LLLL');
 ```


### PR DESCRIPTION
replaced `import moment = require('moment')` with `const moment = require('moment')`