### PR TITLE
Fixed min/max deprecation warning in docs

### DIFF
--- a/guides/moment/02-warnings/06-min-max.md
+++ b/guides/moment/02-warnings/06-min-max.md
@@ -2,8 +2,8 @@
 title: Min/Max
 ---
 ```
-moment().min is deprecated, use moment.max
-moment().max is deprecated, use moment.min
+moment().min is deprecated, use moment.min
+moment().max is deprecated, use moment.max
 ```
 
 This warning is not a typo, but it is confusing.


### PR DESCRIPTION
I just noticed this when browsing the docs.
I assume it's a mistake and the names have not switched but to be honest I haven't verified.