### PR TITLE
Update links to moment.github.io/luxon

### DIFF
--- a/docs/moment/-project-status/00-intro.md
+++ b/docs/moment/-project-status/00-intro.md
@@ -56,7 +56,7 @@ In most cases, you should not choose Moment for new projects.  However there are
 
 #### Browser support
 
-Moment works well on Internet Explorer 8 and higher.  By contrast, Luxon only works on IE 10 and higher and requires a polyfill to do so.  [You can read more in Luxon's documentation.](https://moment.github.io/luxon/docs/manual/matrix.html)
+Moment works well on Internet Explorer 8 and higher.  By contrast, Luxon only works on IE 10 and higher and requires a polyfill to do so.  [You can read more in Luxon's documentation.](https://moment.github.io/luxon/#/matrix)
 
 Other libraries have also had issues with Safari, especially on mobile devices.  If you have a strong requirement to support older browsers, then you might want to stick with Moment for a bit longer.
 

--- a/docs/moment/-project-status/01-recommendations.md
+++ b/docs/moment/-project-status/01-recommendations.md
@@ -15,7 +15,7 @@ When choosing, consider that:
 ### [Luxon](https://moment.github.io/luxon/)
 
 Luxon can be thought of as the evolution of Moment.  It is authored by [Isaac Cambron](https://github.com/icambron), a long-time contributor to Moment.
-Please read [*Why does Luxon exist?*](https://moment.github.io/luxon/docs/manual/why.html) and the [*For Moment users*](https://moment.github.io/luxon/docs/manual/moment.html) pages in the Luxon documentation.
+Please read [*Why does Luxon exist?*](https://moment.github.io/luxon/#/why) and the [*For Moment users*](https://moment.github.io/luxon/#/moment) pages in the Luxon documentation.
 
 - Locales: `Intl` provided
 - Time Zones: `Intl` provided


### PR DESCRIPTION
The format of links into `moment.github.io/luxon/docs` has changed at some point, it seems, so this fixes three broken links - the only ones I can see with the same problem.