### PR TITLE
Fix clock hand movement

### DIFF
--- a/assets/js/core-home.js
+++ b/assets/js/core-home.js
@@ -26,8 +26,8 @@
     function updateClock(){
         var now = moment(),
             second = now.seconds() * 6,
-            minute = now.minutes() * 6 + second / 60,
-            hour = ((now.hours() % 12) / 12) * 360 + 90 + minute / 12;
+            minute = now.minutes() * 6 + second / 10,
+            hour = ((now.hours() % 12) / 12) * 360 + 90 + minute / 2;
 
         $('#hour').css("transform", "rotate(" + hour + "deg)");
         $('#minute').css("transform", "rotate(" + minute + "deg)");


### PR DESCRIPTION
The minute hand needs to move 6 degrees every 60 seconds (60/6=10) and hour hand needs to move 30 degrees every 60 minutes (60/30=2).

Since I copied this years ago and I just fixed it on my site, I'm giving back so others won't fall for the same trap :)