### PR TITLE
Add new guides section for Moment Timezone

### DIFF
--- a/assets/css/common/_docs.scss
+++ b/assets/css/common/_docs.scss
@@ -176,6 +176,10 @@
 	}
 }
 
+.docs-content-guides ol {
+	counter-reset: li 0;
+}
+
 .docs-section {
 	padding-top: 40px;
 }

--- a/guides/moment-timezone/00-lib-concepts/00-intro.md
+++ b/guides/moment-timezone/00-lib-concepts/00-intro.md
@@ -1,0 +1,8 @@
+---
+title: Introductory Concepts
+---
+
+The guides area is designed to help developers learn to better interact with the date and time problem domain, and the Moment Timezone library.
+These guides are specifically limited to concepts around time zones and how they're handled by Moment Timezone.
+
+For more general date and time advice, see the [core Moment.js guides](/guides/).

--- a/guides/moment-timezone/00-lib-concepts/01-timezone-offset.md
+++ b/guides/moment-timezone/00-lib-concepts/01-timezone-offset.md
@@ -1,0 +1,10 @@
+---
+title: Time Zone vs Offset
+---
+
+Frequently, people are confused about the difference between time zones and UTC offsets. 
+
+The core Moment.js documentation has [a guide on this topic](/guides/#/lib-concepts/timezone-offset/) that is worth reading first.
+Logically it belongs in the guides for Moment Timezone, but it predates this guide section by many years, and moving it would break a lot of links on the internet.
+
+<a href="https://stackoverflow.com/tags/timezone/info" target="_blank" >For an in depth description of zones vs offsets, see the Stack Overflow tag.</a>

--- a/guides/moment-timezone/01-data-calculations/00-intro.md
+++ b/guides/moment-timezone/01-data-calculations/00-intro.md
@@ -1,0 +1,8 @@
+---
+title: Data and Calculations
+---
+
+Moment Timezone enhances the core Moment.js functionality by using pre-compiled time zone data.
+
+This section describes where the data comes from, its limitations, and some quirks of real-world time zone rules.
+The technical details of the data format are described in the [API documentation](/timezone/docs/#/data-formats/).

--- a/guides/moment-timezone/01-data-calculations/01-data-source.md
+++ b/guides/moment-timezone/01-data-calculations/01-data-source.md
@@ -1,0 +1,16 @@
+---
+title: Data Source
+---
+
+All time zone data in Moment Timezone comes from the [IANA Time Zone Database ("tzdb")](https://www.iana.org/time-zones).
+Moment Timezone consumes the default data directly from the tzdb, using only the published releases.
+The only changes the library makes are to convert the data to a [custom JSON format](/timezone/docs/#/data-formats/), and optionally restrict how many years of data to use.
+
+Any pull requests that make changes to the compiled data files _without_ being derived from a tzdb release will be rejected.
+
+If you think that the data used by Moment Timezone is incorrect, the ideal order of actions to follow is:
+
+1. Make sure you've upgraded to the latest version of the library. We try to closely track the tzdb releases, so upgrading Moment Timezone resolves most cases of out-of-date data.
+2. For data calculation problems, raise an issue in the [Moment Timezone issue tracker](https://github.com/moment/moment-timezone/issues).
+3. For other problems (such as creating a new zone definition), search the [archives of the tzdb mailing list](https://mm.icann.org/pipermail/tz/). It's probable that new data changes or zone definitions are already being discussed, but haven't made it to a published release yet.
+4. If there is nothing in the tzdb archives, send a message to the mailing list at <a href="mailto:tz@iana.org">tz@iana.org</a>.

--- a/guides/moment-timezone/01-data-calculations/02-limited-range.md
+++ b/guides/moment-timezone/01-data-calculations/02-limited-range.md
@@ -1,0 +1,29 @@
+---
+title: Limited Data Ranges
+---
+
+By default, Moment Timezone includes all the data from the [IANA Time Zone Database ("tzdb")](https://www.iana.org/time-zones).
+This covers past data as far back as the 1800s for some zones, and future data up to the year 2499.
+This is usually more data than required by most applications, so there are also some pre-built data bundles available with more limited year ranges.
+These are listed on the [project homepage](/timezone) and the ["Where to use it" documentation](/timezone/docs/#/use-it)
+(or you can use [utility functions](/timezone/docs/#/data-utilities/filter-years/) to create custom date ranges).
+
+A question that often pops up with these limited bundles is: **What happens for dates outside the range of the data?**
+For example, if the loaded data only covers 2012 to 2022, and a date is calculated for 2023, or 2010, what is the calculated UTC offset for that date?
+
+Due to the structure of the [data format](/timezone/docs/#/data-formats/), the time zone rules at the boundaries of the data range are
+assumed to extended infinitely into the past and future. This produces the following behaviour:
+
+* For dates before the start of the data range, the first rule found in the data for that time zone is used.
+* For dates after the end of the data range, the last rule found in the data for that time zone is used.
+
+As an example, let's say a project is using a data file that covers only 2015 to 2025, and wants to calculate the time in Sydney, Australia some time in 2026.
+
+* The zone `Australia/Sydney` has a base (standard) offset of `UTC+10:00` from April to September each year.
+  Daylight Saving Time (DST) in Sydney applies from October to March, putting the offset at `UTC+11:00`.
+* Since DST is active when a year ends, and therefore when the data range ends, the DST offset will be used for all future dates.
+* Therefore, calculating a date in 2026 from January to March will get an offset of `UTC+11:00`. This is correct, but only _by accident_.
+  Calculating a date after March in 2026 will still get an offset of `UTC+11:00`, even though the real value should be `UTC+10:00`.
+  This is when bugs will start to appear.
+
+The best fix for these calculation problems is to make sure you're using a data range that covers all the dates your project needs.

--- a/pages/moment-timezone/guides.hbs
+++ b/pages/moment-timezone/guides.hbs
@@ -1,0 +1,15 @@
+---
+title   : Guides
+layout  : moment-timezone-base.hbs
+order   : 2
+scripts :
+    - docs
+---
+
+<div class="hero hero-oneline">
+	<div class="hero-centered">
+		<h1>Moment Timezone Guides</h1>
+	</div>
+</div>
+
+{{>guides-partial}}

--- a/pages/moment-timezone/tests.hbs
+++ b/pages/moment-timezone/tests.hbs
@@ -1,7 +1,7 @@
 ---
 title   : Tests
 layout  : moment-timezone-base.hbs
-order   : 2
+order   : 3
 scripts :
   - timezone-test
 ---

--- a/pages/partials/guides-partial.hbs
+++ b/pages/partials/guides-partial.hbs
@@ -12,7 +12,7 @@
 		{{/each}}
 	</div>
 
-	<div class="docs-content">
+	<div class="docs-content docs-content-guides">
 		{{#each guides}}
 			<article class="docs-section">
 				<a class="docs-section-target" id="/{{ slug }}/" name="/{{ slug }}/"></a>

--- a/pages/partials/guides-partial.hbs
+++ b/pages/partials/guides-partial.hbs
@@ -36,7 +36,7 @@
 								{{#markdown}}```js{{{ signature }}}```{{/markdown}}
 							</div>
 						{{/if}}
-						{{#markdown}}
+						{{#markdown breaks=false}}
 							{{{body}}}
 						{{/markdown}}
 					</div>

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -36,7 +36,8 @@ module.exports = function(grunt) {
 		},
 		'moment-timezone' : {
 			options : {
-				docs : docs('docs', 'moment-timezone')
+				docs : docs('docs', 'moment-timezone'),
+				guides: docs('guides', 'moment-timezone')
 			},
 			files: [{
 				expand : true,
@@ -54,12 +55,12 @@ module.exports = function(grunt) {
 	]);
 
 	grunt.config('watch.html-moment', {
-		files: ['{pages,docs/moment}/**/*.{hbs,json,md,js}'],
+		files: ['{pages,docs/moment,guides/moment}/**/*.{hbs,json,md,js}'],
 		tasks: ['assemble:moment']
 	});
 
 	grunt.config('watch.html-moment-timezone', {
-		files: ['{pages,docs/moment-timezone}/**/*.{hbs,json,md,js}'],
+		files: ['{pages,docs/moment-timezone,guides/moment-timezone}/**/*.{hbs,json,md,js}'],
 		tasks: ['assemble:moment-timezone']
 	});
 };


### PR DESCRIPTION
There are some common questions popping up in the issue tracker that deserve some permanent answers in the docs. The best place to put the answers is in the Guides section, but it didn't feel right to put Timezone-specific problems in the generic Moment guides.

This PR adds a new Guides section for Moment Timezone, with a couple of initial sections. I also made the markdown in all guides ignore single line breaks for better readability (this was already active for the regular docs, but had been missed for the guides).

<img width="1013" alt="image" src="https://user-images.githubusercontent.com/159415/234168292-6d98ba29-b8c6-4b3d-a217-b36d9d975d80.png">
