### PR TITLE
Update Temporal API description

### DIFF
--- a/docs/moment/-project-status/02-future.md
+++ b/docs/moment/-project-status/02-future.md
@@ -10,7 +10,7 @@ Though some capabilities are here today with [`Date`](https://developer.mozilla.
 The effort to make better date and time APIs in the JavaScript language is being done via [The ECMA TC39 Temporal Proposal](https://tc39.es/proposal-temporal/docs/index.html).
 It is currently at Stage 3 of [the TC39 process](https://tc39.es/process-document/).
 
-`Temporal` will be a new global object that acts as a top-level namespace (like `Math`).  It exposes many separate types of objects including `Temporal.Instant`, `Temporal.ZonedDateTime`, `Temporal.PlainDateTime`, `Temporal.PlainDate`, `Temporal.PlainTime`, `Temporal.TimeZone` and several others.  The [Temporal Cookbook](https://tc39.es/proposal-temporal/docs/cookbook.html) shows many "recipes" with examples of how these objects can be used in different scenarios.
+[`Temporal`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) will be a new global object that acts as a top-level namespace (like `Math`).  It exposes many separate types of objects including `Temporal.Instant`, `Temporal.ZonedDateTime`, `Temporal.PlainDateTime`, `Temporal.PlainDate`, `Temporal.PlainTime` and several others.  The [Temporal Cookbook](https://tc39.es/proposal-temporal/docs/cookbook.html) shows many "recipes" with examples of how these objects can be used in different scenarios.
 
 You can try out Temporal today, via [a non-production polyfill](https://github.com/tc39/proposal-temporal/tree/main/polyfill).  Please give it a try, but don't use it in production (yet)!
 


### PR DESCRIPTION
I noticed the page describing the Temporal API was slightly out of date. I've removed the reference to `Temporal.TimeZone` as it was removed from the spec last year and added a link to the MDN documentation.