### PR TITLE
chore: remove nuget from docs

### DIFF
--- a/docs/moment/00-use-it/05-nuget.md
+++ b/docs/moment/00-use-it/05-nuget.md
@@ -1,8 +1,0 @@
----
-title: NuGet
----
-
-[NuGet](https://www.nuget.org/) / [Moment.js](https://www.nuget.org/packages/Moment.js/)
-```
-Install-Package Moment.js
-```

--- a/pages/moment/index.hbs
+++ b/pages/moment/index.hbs
@@ -51,7 +51,6 @@ scripts :
 		<h3>Install</h3>
 		<pre><code>npm install moment --save   <span class="comment"># npm</span>
 yarn add moment             <span class="comment"># Yarn</span>
-Install-Package Moment.js   <span class="comment"># NuGet</span>
 spm install moment --save   <span class="comment"># spm</span>
 meteor add momentjs:moment  <span class="comment"># meteor</span>
 bower install moment --save <span class="comment"># bower (deprecated)</span>


### PR DESCRIPTION
Nuget releases are deprecated and should be removed from docs.

For context - a _very_ long time ago, it was common for .NET developers to get all their dependencies from Nuget, including JavaScript dependencies for ASP.NET applications.  This practice is long dead.  .NET developers now get their JavaScript dependencies from NPM, just like everyone else.

I have also marked the Nuget packages themselves as deprecated.